### PR TITLE
Updated to support Python 3.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.egg-info
+bad.txt
+test_codegen_dump_1.txt
+test_codegen_dump_2.txt

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,20 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
+import sys
 
 def readdoc():
-    f = open('README.rst', 'rb')
+    if sys.version_info[0] >= 3:
+        f = open('README.rst')
+    else:
+        f = open('README.rst', 'rb')
     data = f.read()
     f.close()
     return data
 
 setup(
     name='astor',
-    version='0.2.1',
+    version='0.2.2',
     description='Read/rewrite/write Python ASTs',
     long_description=readdoc(),
     author='Patrick Maupin',

--- a/test/nested_with_for_tests.py
+++ b/test/nested_with_for_tests.py
@@ -1,0 +1,14 @@
+class A(object):
+    pass
+
+class B(object):
+    pass
+
+def test():
+    with A() as a:
+        with B() as b:
+            print ("test1")
+
+def test2():
+    with A() as a, B() as b:
+        print ("test2")


### PR DESCRIPTION
There are a few updates to Try, With and a new YieldFrom that
are necessary for Python 3.3 support. Also bumped the version
to 0.2.2 and changed to setuptools so that 'python setup.py develop'
is available.

Tested with Python 2.6, 2.7, 3.2, and 3.3
