### PR TITLE
Fix Python 3 installation.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,14 +3,13 @@
 from distutils.core import setup
 
 def readdoc():
-    f = open('README.rst', 'rb')
-    data = f.read()
-    f.close()
+    with open('README.rst') as fobj:
+        data = fobj.read()
     return data
 
 setup(
     name='astor',
-    version='0.2.1',
+    version='0.2.2',
     description='Read/rewrite/write Python ASTs',
     long_description=readdoc(),
     author='Patrick Maupin',
@@ -25,9 +24,13 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 3',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
         'Topic :: Software Development :: Code Generators',
         'Topic :: Software Development :: Compilers',
     ],


### PR DESCRIPTION
In Python 3, the long_description field should not be a bytes object.

I also cleanup the Python version classfiers.

Note: This issue can be reproduced by installing astor manually(e.g.
python3 setup.py install) or adding astor to install_requires in your
project(e.g. https://github.com/hylang/hy/pull/328/files)
