### PR TITLE
Adding a standard .gitignore for py projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,39 @@
-*.egg-info
-build/
-dist/
 bad.txt
 test_codegen_dump_1.txt
 test_codegen_dump_2.txt
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Distribution / packaging
+.Python
+env/
+bin/
+build/
+develop-eggs/
+dist/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Sphinx documentation
+docs/_build/


### PR DESCRIPTION
This commit adds a standard .gitignore for python projects primarily
ignoring Distribution/packaging files doc build files (which for this
repo might be needed in future) etc.
