### PR TITLE
Add visitor for NameConstant (PY34)

### DIFF
--- a/astor/codegen.py
+++ b/astor/codegen.py
@@ -254,6 +254,9 @@ class SourceGenerator(ExplicitNodeVisitor):
         self.write(node.context_expr)
         self.conditional_write(' as ', node.optional_vars)
 
+    def visit_NameConstant(self, node):
+        self.write(node.value)
+
     def visit_Pass(self, node):
         self.statement(node, 'pass')
 


### PR DESCRIPTION
NameConstant node was introduced in Python 3.4 for True, False & None
values. This fixes #10
