### PR TITLE
add support for Python 3.5 infix matrix multiplication

### DIFF
--- a/astor/misc.py
+++ b/astor/misc.py
@@ -10,6 +10,7 @@ Copyright 2013 (c) Berker Peksag
 """
 
 import ast
+import sys
 
 
 class NonExistent(object):
@@ -118,13 +119,18 @@ get_boolop = _getsymbol("""
     And and   Or or
 """, all_symbols)
 
-get_binop = _getsymbol("""
+binops = """
     Add +   Mult *   LShift <<   BitAnd &
     Sub -   Div  /   RShift >>   BitOr  |
             Mod  %               BitXor ^
             FloorDiv //
             Pow **
-""", all_symbols)
+"""
+if sys.version_info >= (3, 5):
+    binops += "MatMult @"
+
+
+get_binop = _getsymbol(binops, all_symbols)
 
 get_cmpop = _getsymbol("""
   Eq    ==   Gt >   GtE >=   In    in       Is    is

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: Implementation',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -7,8 +7,13 @@ Copyright 2014 (c) Berker Peksag
 """
 
 import ast
-import unittest
+import sys
 import textwrap
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 import astor
 
@@ -54,6 +59,15 @@ class CodegenTestCase(unittest.TestCase):
         def test(a1, a2, b1=j, b2='123', b3={}, b4=[]):
             pass""")
         self.assertAstSourceEqual(source)
+
+    def test_matrix_multiplication(self):
+        for source in ("(a @ b)", "a @= b"):
+            if sys.version_info >= (3, 5):
+                self.assertAstSourceEqual(source)
+            else:
+                # matrix multiplication operator introduced in Python 3.5
+                self.assertRaises(SyntaxError, ast.parse, source)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,22 @@
+import ast
+import unittest
+import sys
+
+import astor
+
+
+class GetSymbolTestCase(unittest.TestCase):
+
+    def test_get_mat_mult(self):
+        if sys.version_info < (2, 7):
+            # We can't use `@unittest.skipIf` or `raise skipTest` in
+            # Python 2.6
+            pass
+        elif sys.version_info < (3, 5):
+            raise unittest.SkipTest("ast.MatMult introduced in Python 3.5")
+        else:
+            self.assertEqual('@', astor.misc.get_binop(ast.MatMult()))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,22 +1,20 @@
 import ast
-import unittest
 import sys
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 import astor
 
 
 class GetSymbolTestCase(unittest.TestCase):
 
+    @unittest.skipUnless(sys.version_info >= (3, 5),
+                         "ast.MatMult introduced in Python 3.5")
     def test_get_mat_mult(self):
-        if sys.version_info < (2, 7):
-            # We can't use `@unittest.skipIf` or `raise skipTest` in
-            # Python 2.6
-            pass
-        elif sys.version_info < (3, 5):
-            raise unittest.SkipTest("ast.MatMult introduced in Python 3.5")
-        else:
-            self.assertEqual('@', astor.misc.get_binop(ast.MatMult()))
-
+        self.assertEqual('@', astor.misc.get_binop(ast.MatMult()))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This came up while working on a momentarily forthcoming pull request (the topic of which can be easily inferred) for Hy.