### PR TITLE
Python 3.5 iterable unpacking and async syntax; idiomatic dictionary literals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,12 +16,15 @@ dist/
 eggs/
 lib/
 lib64/
+lib64
 parts/
 sdist/
 var/
 *.egg-info/
 .installed.cfg
 *.egg
+pyvenv.cfg
+pip-selfcheck.json
 
 # Installer logs
 pip-log.txt

--- a/astor/codegen.py
+++ b/astor/codegen.py
@@ -407,8 +407,10 @@ class SourceGenerator(ExplicitNodeVisitor):
 
     @enclose('{}')
     def visit_Dict(self, node):
-        for key, value in zip(node.keys, node.values):
-            self.write(key, ': ', value, ', ')
+        for idx, (key, value) in enumerate(zip(node.keys, node.values)):
+            if idx:
+                self.write(', ')
+            self.write(key, ': ', value)
 
     @enclose('()')
     def visit_BinOp(self, node):

--- a/astor/codegen.py
+++ b/astor/codegen.py
@@ -179,15 +179,20 @@ class SourceGenerator(ExplicitNodeVisitor):
         self.statement(node)
         self.generic_visit(node)
 
-    def visit_FunctionDef(self, node):
+    def visit_FunctionDef(self, node, async=False):
         self.decorators(node, 1)
-        self.statement(node, 'def %s(' % node.name)
+        self.statement(node, '%sdef %s(' %
+                       ('async ' if async else '', node.name))
         self.signature(node.args)
         self.write(')')
         if getattr(node, 'returns', None) is not None:
             self.write(' ->', node.returns)
         self.write(':')
         self.body(node.body)
+
+    # introduced in Python 3.5
+    def visit_AsyncFunctionDef(self, node):
+        self.visit_FunctionDef(node, async=True)
 
     def visit_ClassDef(self, node):
         have_args = []
@@ -458,6 +463,11 @@ class SourceGenerator(ExplicitNodeVisitor):
     # new for Python 3.3
     def visit_YieldFrom(self, node):
         self.write('yield from ')
+        self.visit(node.value)
+
+    # new for Python 3.5
+    def visit_Await(self, node):
+        self.write('await ')
         self.visit(node.value)
 
     @enclose('()')

--- a/astor/codegen.py
+++ b/astor/codegen.py
@@ -232,21 +232,26 @@ class SourceGenerator(ExplicitNodeVisitor):
                 self.else_body(else_)
                 break
 
-    def visit_For(self, node):
-        self.statement(node, 'for ', node.target, ' in ', node.iter, ':')
+    def visit_For(self, node, async=False):
+        self.statement(node, '%sfor ' % ('async ' if async else ''),
+                       node.target, ' in ', node.iter, ':')
         self.body_or_else(node)
+
+    # introduced in Python 3.5
+    def visit_AsyncFor(self, node):
+        self.visit_For(node, async=True)
 
     def visit_While(self, node):
         self.statement(node, 'while ', node.test, ':')
         self.body_or_else(node)
 
-    def visit_With(self, node):
+    def visit_With(self, node, async=False):
         if hasattr(node, "context_expr"):  # Python < 3.3
             self.statement(node, 'with ', node.context_expr)
             self.conditional_write(' as ', node.optional_vars)
             self.write(':')
         else:                              # Python >= 3.3
-            self.statement(node, 'with ')
+            self.statement(node, '%swith ' % ('async ' if async else ''))
             count = 0
             for item in node.items:
                 if count > 0:
@@ -255,6 +260,10 @@ class SourceGenerator(ExplicitNodeVisitor):
                 count += 1
             self.write(':')
         self.body(node.body)
+
+    # new for Python 3.5
+    def visit_AsyncWith(self, node):
+        self.visit_With(node, async=True)
 
     # new for Python 3.3
     def visit_withitem(self, node):

--- a/astor/codegen.py
+++ b/astor/codegen.py
@@ -212,7 +212,10 @@ class SourceGenerator(ExplicitNodeVisitor):
         #      with python 2.6.
         if hasattr(node, 'keywords'):
             for keyword in node.keywords:
-                self.write(paren_or_comma, keyword.arg, '=', keyword.value)
+                if keyword.arg is None:
+                    self.write(paren_or_comma, '**', keyword.value)
+                else:
+                    self.write(paren_or_comma, keyword.arg, '=', keyword.value)
             if sys.version_info < (3, 5):
                 self.conditional_write(paren_or_comma, '*', node.starargs)
                 self.conditional_write(paren_or_comma, '**', node.kwargs)

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -31,6 +31,12 @@ class CodegenTestCase(unittest.TestCase):
         source = "from math import floor"
         self.assertAstSourceEqual(source)
 
+    def test_dictionary_literals(self):
+        source = "{'a': 1, 'b': 2}"
+        self.assertAstSourceEqual(source)
+        another_source = "{'nested': ['structures', {'are': 'important'}]}"
+        self.assertAstSourceEqual(another_source)
+
     def test_try_expect(self):
         source = textwrap.dedent("""\
         try:
@@ -80,10 +86,8 @@ class CodegenTestCase(unittest.TestCase):
                 self.assertRaises(SyntaxError, ast.parse, source)
 
     def test_multiple_unpackings(self):
-        # XXX TODO: no human Pythonista would write the contents of a
-        # dictionary literal with a trailing comma-space like that
         source = textwrap.dedent("""\
-        my_function(*[1], *[2], **{'three': 3, }, **{'four': 'four', })""")
+        my_function(*[1], *[2], **{'three': 3}, **{'four': 'four'})""")
         if sys.version_info >= (3, 5):
             self.assertAstSourceEqual(source)
         else:

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -23,6 +23,12 @@ class CodegenTestCase(unittest.TestCase):
     def assertAstSourceEqual(self, source):
         self.assertEqual(astor.to_source(ast.parse(source)), source)
 
+    def assertAstSourceEqualIfAtLeastVersion(self, source, version_tuple):
+        if sys.version_info >= version_tuple:
+            self.assertAstSourceEqual(source)
+        else:
+            self.assertRaises(SyntaxError, ast.parse, source)
+
     def test_imports(self):
         source = "import ast"
         self.assertAstSourceEqual(source)
@@ -79,19 +85,12 @@ class CodegenTestCase(unittest.TestCase):
 
     def test_matrix_multiplication(self):
         for source in ("(a @ b)", "a @= b"):
-            if sys.version_info >= (3, 5):
-                self.assertAstSourceEqual(source)
-            else:
-                # matrix multiplication operator introduced in Python 3.5
-                self.assertRaises(SyntaxError, ast.parse, source)
+            self.assertAstSourceEqualIfAtLeastVersion(source, (3, 5))
 
     def test_multiple_unpackings(self):
         source = textwrap.dedent("""\
         my_function(*[1], *[2], **{'three': 3}, **{'four': 'four'})""")
-        if sys.version_info >= (3, 5):
-            self.assertAstSourceEqual(source)
-        else:
-            self.assertRaises(SyntaxError, ast.parse, source)
+        self.assertAstSourceEqualIfAtLeastVersion(source, (3, 5))
 
     def test_async_def_with_for(self):
         source = textwrap.dedent("""\
@@ -101,10 +100,7 @@ class CodegenTestCase(unittest.TestCase):
             async for datum in data:
                 if quux(datum):
                     return datum""")
-        if sys.version_info >= (3, 5):
-            self.assertAstSourceEqual(source)
-        else:
-            self.assertRaises(SyntaxError, ast.parse, source)
+        self.assertAstSourceEqualIfAtLeastVersion(source, (3, 5))
 
 
 if __name__ == '__main__':

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -79,6 +79,16 @@ class CodegenTestCase(unittest.TestCase):
                 # matrix multiplication operator introduced in Python 3.5
                 self.assertRaises(SyntaxError, ast.parse, source)
 
+    def test_multiple_unpackings(self):
+        # XXX TODO: no human Pythonista would write the contents of a
+        # dictionary literal with a trailing comma-space like that
+        source = textwrap.dedent("""\
+        my_function(*[1], *[2], **{'three': 3, }, **{'four': 'four', })""")
+        if sys.version_info >= (3, 5):
+            self.assertAstSourceEqual(source)
+        else:
+            self.assertRaises(SyntaxError, ast.parse, source)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -93,6 +93,16 @@ class CodegenTestCase(unittest.TestCase):
         else:
             self.assertRaises(SyntaxError, ast.parse, source)
 
+    def test_async_function_definition(self):
+        source = textwrap.dedent("""\
+        async def read_data(db):
+            data = await db.fetch('SELECT foo FROM bar;')
+            return quux(data)""")
+        if sys.version_info >= (3, 5):
+            self.assertAstSourceEqual(source)
+        else:
+            self.assertRaises(SyntaxError, ast.parse, source)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -93,11 +93,14 @@ class CodegenTestCase(unittest.TestCase):
         else:
             self.assertRaises(SyntaxError, ast.parse, source)
 
-    def test_async_function_definition(self):
+    def test_async_def_with_for(self):
         source = textwrap.dedent("""\
         async def read_data(db):
-            data = await db.fetch('SELECT foo FROM bar;')
-            return quux(data)""")
+            async with connect(db) as db_cxn:
+                data = await db_cxn.fetch('SELECT foo FROM bar;')
+            async for datum in data:
+                if quux(datum):
+                    return datum""")
         if sys.version_info >= (3, 5):
             self.assertAstSourceEqual(source)
         else:

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -102,6 +102,12 @@ class CodegenTestCase(unittest.TestCase):
                     return datum""")
         self.assertAstSourceEqualIfAtLeastVersion(source, (3, 5))
 
+    def test_class_definition_with_starbases_and_kwargs(self):
+        source = textwrap.dedent("""\
+        class TreeFactory(*[FactoryMixin, TreeBase], **{'metaclass': Foo}):
+            pass""")
+        self.assertAstSourceEqualIfAtLeastVersion(source, (3, 0))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This pull request proposes of implementation of support in astor for two new-in-Python 3.5 syntactic features, namely [additional unpacking generalizations](https://www.python.org/dev/peps/pep-0448/) and [coroutines with async and await syntax](https://www.python.org/dev/peps/pep-0492/). Also, it is proposed that code-generation for dictionary literals not include a trailing comma and space, to better reflect most actual Python code.

Developed against python/cpython@c4766cf152.
