### PR TITLE
non-call dictionary unpacking

### DIFF
--- a/astor/codegen.py
+++ b/astor/codegen.py
@@ -427,7 +427,10 @@ class SourceGenerator(ExplicitNodeVisitor):
         for idx, (key, value) in enumerate(zip(node.keys, node.values)):
             if idx:
                 self.write(', ')
-            self.write(key, ': ', value)
+            if key is None:
+                self.write('**', value)
+            else:
+                self.write(key, ': ', value)
 
     @enclose('()')
     def visit_BinOp(self, node):

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -87,9 +87,14 @@ class CodegenTestCase(unittest.TestCase):
         for source in ("(a @ b)", "a @= b"):
             self.assertAstSourceEqualIfAtLeastVersion(source, (3, 5))
 
-    def test_multiple_unpackings(self):
+    def test_multiple_call_unpackings(self):
         source = textwrap.dedent("""\
         my_function(*[1], *[2], **{'three': 3}, **{'four': 'four'})""")
+        self.assertAstSourceEqualIfAtLeastVersion(source, (3, 5))
+
+    def test_right_hand_side_dictionary_unpacking(self):
+        source = textwrap.dedent("""\
+        our_dict = {'a': 1, **{'b': 2, 'c': 3}}""")
         self.assertAstSourceEqualIfAtLeastVersion(source, (3, 5))
 
     def test_async_def_with_for(self):


### PR DESCRIPTION
This really ought to have been part of #19, but the author of that pull request would seem to have forgotten it.

(Also, a confession: I was also going to add a test for the new way to use iterable unpacking in expressions like this—

``` python
    def test_right_hand_side_iterable_unpacking(self):
        source = textwrap.dedent("""\
        one_to_ten = [*range(1, 8), 8, 9, 10]""")
        self.assertAstSourceEqualIfAtLeastVersion(source, (3, 5))
```

But then it turns out that this doesn't pass on all Python versions for the "spurious" reason that on Python >=3.0 but <=3.4, while trying to *run* that source code does raise a `SyntaxError`, merely calling `ast.parse` on it (as our `assertAstSourceEqualIfAtLeastVersion` test helper does) does *not*, one imagines because `Starred(value=Call(func=Name(id='range', ctx=Load()), args=[Num(n=1), Num(n=8)], keywords=[], starargs=None, kwargs=None), ctx=Load())` is in fact a valid AST node even if we're not allowed to use it like that (and Python doesn't notice the mistake until after the AST-generation phase). Rather than spend more time fixing the test helper method, I decided to just omit the test and just pull-request the dictionary-unpacking fix, which was my primary goal.)