### PR TITLE
tweak code style regarding async variants of `def`, `for`, and `with` visitors

### DIFF
--- a/astor/codegen.py
+++ b/astor/codegen.py
@@ -180,9 +180,11 @@ class SourceGenerator(ExplicitNodeVisitor):
         self.generic_visit(node)
 
     def visit_FunctionDef(self, node, async=False):
+        def_statement = 'def'
+        if async:
+            def_statement = 'async ' + def_statement
         self.decorators(node, 1)
-        self.statement(node, '%sdef %s(' %
-                       ('async ' if async else '', node.name))
+        self.statement(node, '%s %s(' % (def_statement, node.name))
         self.signature(node.args)
         self.write(')')
         if getattr(node, 'returns', None) is not None:
@@ -236,8 +238,11 @@ class SourceGenerator(ExplicitNodeVisitor):
                 break
 
     def visit_For(self, node, async=False):
-        self.statement(node, '%sfor ' % ('async ' if async else ''),
-                       node.target, ' in ', node.iter, ':')
+        for_statement = 'for'
+        if async:
+            for_statement = 'async ' + for_statement
+        self.statement(node, '%s ' % for_statement, node.target,
+                       ' in ', node.iter, ':')
         self.body_or_else(node)
 
     # introduced in Python 3.5
@@ -254,7 +259,10 @@ class SourceGenerator(ExplicitNodeVisitor):
             self.conditional_write(' as ', node.optional_vars)
             self.write(':')
         else:                              # Python >= 3.3
-            self.statement(node, '%swith ' % ('async ' if async else ''))
+            with_statement = 'with'
+            if async:
+                with_statement = 'async ' + with_statement
+            self.statement(node, '%s ' % with_statement)
             count = 0
             for item in node.items:
                 if count > 0:


### PR DESCRIPTION
This is in response to astor maintainer @pmaupin's [comment on #19](https://github.com/berkerpeksag/astor/pull/19#issuecomment-102454878) suggesting that a clearer way of modifying the `def`, `for`, and `with` visitor methods to also support the [PEP 492](https://www.python.org/dev/peps/pep-0492/) async variants would be for these methods to accept an optional argument specifying the keyword(s) to be used (*e.g.*, for `visit_FunctionDef`, the optional argument would default to `'def'`, but  `visit_AsyncFunctionDef` would pass in `'async def'` instead.) 

I agree that the style used in #19, of using the ternary expression `'async ' if async else ''` as a string-formatting argument, is kind of ugly and cluttered, but on the other hand, I do think it's desirable for the argument signatures of the visitor methods of `SourceGenerator` to reflect the attributes of the underlying AST: 64f44448's `visit_FunctionDef(self, node, async=False)` will generate a fragment of valid Python no matter whether `async` is truthy or falsey, whereas a `visit_FunctionDef(self, node, defstmt='def')` variant that templates in the value of `defstmt` will not, for most possible values of `defstmt`.

The changes proposed in this pull request are intended to keep the argument signatures as in #19, but express the normal *vs.* async conditional in an arguably more pleasant-to-read way than the previous ternary expression templating. (Alternatively, we could imagine having both `visit_FunctionDef` and `visit_asyncFunctionDef` delegate to a private method, call it `_base_visit_FunctionDef(self, node, stmt)`, that templates in the value of statement, and having `visit_FunctionDef` and `visit_FunctionDef` pass in `stmt='def'` and `stmt='async def'` respectively, but I like the way that the current implementation emphasizes that the async versions are mere variants of our trusty, ubuquitous, ordinary `def`, `for`, and `with` statements.)