### PR TITLE
Added new anti8 example utility; used it to find and fix bugs

### DIFF
--- a/examples/anti8.py
+++ b/examples/anti8.py
@@ -1,0 +1,105 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Part of the astor library for Python AST manipulation.
+
+License: 3-clause BSD
+
+Copyright 2015 (c) Patrick Maupin
+
+The purpose of anti8 is to place Python code into a canonical form --
+     that just happens to be about as far away from PEP 8 as you can get.
+
+How is this possibly useful?
+
+Well, for a start, since it is a canonical form, you can compare the anti8
+representation of a source tree against the anti8 representation of the
+same tree after a PEP8 tool was run on it.
+
+Or, maybe more importantly, after manual edits were made in the name
+of PEP8.  Trust, but verify.
+
+Note 1: The canonical form is only canonical for a given version of
+        this module and the astor toolbox.  It is not guaranteed to
+        be stable.  The only desired guarantee is that two source modules
+        that parse to the same AST will be converted back into the same
+        canonical form.
+
+Note 2: This tool WILL TRASH the tmp_anti8 directory -- as far as it is
+        concerned, it OWNS that directory.
+
+Note 3: This tools WILL CRASH if you don't give it exactly one parameter
+        on the command line -- the top of the tree you want to apply
+        anti8 to.  You can read the traceback and figure this out, right?
+"""
+
+import sys
+import os
+import ast
+import shutil
+import logging
+
+try:
+    import astor
+except ImportError:
+    exampledir = os.path.dirname(os.path.abspath(sys.argv[0]))
+    rootdir = os.path.dirname(exampledir)
+    sys.path.insert(0, rootdir)
+    import astor
+
+
+class StripLineCol(ast.NodeVisitor):
+    """Strip the line and column numbers from the tree
+
+    """
+
+    def visit(self, node):
+        """Visit a node."""
+        for kill in ('lineno', 'col_offset'):
+            if hasattr(node, kill):
+                delattr(node, kill)
+
+striplinecol = StripLineCol().visit
+
+
+def convert(srctree, dsttree='tmp_anti8'):
+    """Walk the srctree, and convert/copy all python files
+    into the dsttree
+
+    """
+
+    srctree = os.path.normpath(srctree)
+    dsttree = os.path.normpath(dsttree)
+
+    logging.info('')
+    logging.info('Trashing ' + dsttree)
+    shutil.rmtree(dsttree, True)
+
+    for srcpath, _, fnames in os.walk(srctree):
+        # Avoid infinite recursion for silly users
+        print dsttree, srcpath, dsttree in srcpath
+        if dsttree in srcpath:
+            continue
+        dstpath = srcpath.replace(srctree, dsttree, 1)
+        logging.info('')
+        logging.info('Creating ' + dstpath)
+        os.mkdir(dstpath)
+        for fname in (x for x in fnames if x.endswith('.py')):
+            logging.info('    Converting ' + fname)
+            srcfname = os.path.join(srcpath, fname)
+            dstfname = os.path.join(dstpath, fname)
+            srcast = astor.parsefile(srcfname)
+            with open(dstfname, 'w') as f:
+                f.write(astor.to_source(srcast))
+
+            # As a sanity check, make sure that ASTs themselves
+            # round-trip OK
+            dstast = astor.parsefile(dstfname)
+            if striplinecol(srcast) != striplinecol(dstast):
+                raise ValueError('Round trip of %s failed' % srcfname)
+
+
+if __name__ == '__main__':
+    srctree, = sys.argv[1:]
+    logging.basicConfig(format='%(msg)s', level=logging.INFO)
+    convert(srctree)

--- a/examples/anti8.py
+++ b/examples/anti8.py
@@ -77,7 +77,6 @@ def convert(srctree, dsttree='tmp_anti8'):
 
     for srcpath, _, fnames in os.walk(srctree):
         # Avoid infinite recursion for silly users
-        print dsttree, srcpath, dsttree in srcpath
         if dsttree in srcpath:
             continue
         dstpath = srcpath.replace(srctree, dsttree, 1)

--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,5 @@ setup(
         'Topic :: Software Development :: Code Generators',
         'Topic :: Software Development :: Compilers',
     ],
-    keywords='ast, codegen',
+    keywords='ast, codegen, PEP8, anti8',
 )

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -23,10 +23,12 @@ class CodegenTestCase(unittest.TestCase):
     def assertAstSourceEqual(self, source):
         self.assertEqual(astor.to_source(ast.parse(source)), source)
 
-    def assertAstSourceEqualIfAtLeastVersion(self, source, version_tuple):
+    def assertAstSourceEqualIfAtLeastVersion(self, source, version_tuple, version2=None):
+        if version2 is None:
+            version2 = version_tuple[0], version_tuple[1] - 1
         if sys.version_info >= version_tuple:
             self.assertAstSourceEqual(source)
-        else:
+        elif sys.version_info <= version2:
             self.assertRaises(SyntaxError, ast.parse, source)
 
     def test_imports(self):
@@ -35,6 +37,8 @@ class CodegenTestCase(unittest.TestCase):
         source = "import operator as op"
         self.assertAstSourceEqual(source)
         source = "from math import floor"
+        self.assertAstSourceEqual(source)
+        source = "from .. import foobar"
         self.assertAstSourceEqual(source)
 
     def test_dictionary_literals(self):
@@ -57,6 +61,20 @@ class CodegenTestCase(unittest.TestCase):
         except IndexError as exc:
             sys.stdout.write(exc)""")
         self.assertAstSourceEqual(source)
+
+        source = textwrap.dedent("""\
+        try:
+            'spam'[10]
+        except IndexError as exc:
+            sys.stdout.write(exc)
+        else:
+            pass
+        finally:
+            pass""")
+        # This is interesting -- the latest 2.7 compiler seems to
+        # handle this OK, but creates an AST with nested try/finally
+        # and try/except, so the source code doesn't match.
+        self.assertAstSourceEqualIfAtLeastVersion(source, (3, 4), (1, 0))
 
     def test_del_statement(self):
         source = "del l[0]"
@@ -82,6 +100,11 @@ class CodegenTestCase(unittest.TestCase):
                           if isinstance(n, ast.arguments)][0]
         self.assertEqual(astor.to_source(arguments_node),
                          "a1, a2, b1=j, b2='123', b3={}, b4=[]")
+        source = textwrap.dedent("""\
+        def call(*popenargs, timeout=None, **kwargs):
+            pass""")
+        # Probably also works on < 3.4, but doesn't work on 2.7...
+        self.assertAstSourceEqualIfAtLeastVersion(source, (3, 4), (2, 7))
 
     def test_matrix_multiplication(self):
         for source in ("(a @ b)", "a @= b"):
@@ -107,6 +130,19 @@ class CodegenTestCase(unittest.TestCase):
         class TreeFactory(*[FactoryMixin, TreeBase], **{'metaclass': Foo}):
             pass""")
         self.assertAstSourceEqualIfAtLeastVersion(source, (3, 0))
+
+    def test_yield(self):
+        source = "yield"
+        self.assertAstSourceEqual(source)
+        source = textwrap.dedent("""\
+        def dummy():
+            yield""")
+        self.assertAstSourceEqual(source)
+        source = "foo((yield bar))"
+        self.assertAstSourceEqual(source)
+        source = "return (yield from sam())"
+        # Probably also works on < 3.4, but doesn't work on 2.7...
+        self.assertAstSourceEqualIfAtLeastVersion(source, (3, 4), (2, 7))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Berker:

I'm still pretty new at this git thing, so I probably didn't put this in as many separate commits as some would prefer.  Feel free to slice and dice it anyway you want when updating the master.  (I realize now that I should have done a branch before doing the work, as well, so that's something to try to do next time.)

Anyway, I wrote an example utility to be able to easily compare two source trees (e.g. before and after PEP8 modifications), and ran it on the 2.7 and 3.4 standard libraries, and exposed several bugs in codegen in the process.

For each bug, I wrote a failing testcase and then fixed the bug.

It might be worthwhile to do the same thing for 3.5 before your release, if the goal of the release is 3.5 support.  All you have to do is run the anti8 script with a single parameter that is the path to the system libraries.

It's well past my bedtime, so I don't think I'll have any more code for your new version.

Thanks,
Pat
