### PR TITLE
Yield fixes

### DIFF
--- a/astor/codegen.py
+++ b/astor/codegen.py
@@ -476,19 +476,16 @@ class SourceGenerator(ExplicitNodeVisitor):
     def visit_ExtSlice(self, node):
         self.comma_list(node.dims, len(node.dims) == 1)
 
-    def visit_Yield(self, node, dofrom=False):
-        is_stmt = self.new_lines
-        if not is_stmt:
-            self.write('(')
+    @enclose('()')
+    def visit_Yield(self, node):
         self.write('yield')
-        self.conditional_write(' from' if dofrom else None)
         self.conditional_write(' ', node.value)
-        if not is_stmt:
-            self.write(')')
 
     # new for Python 3.3
+    @enclose('()')
     def visit_YieldFrom(self, node):
-        self.visit_Yield(node, True)
+        self.write('yield from')
+        self.conditional_write(' ', node.value)
 
     # new for Python 3.5
     def visit_Await(self, node):

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -137,13 +137,15 @@ class CodegenTestCase(unittest.TestCase):
         self.assertAstSourceEqualIfAtLeastVersion(source, (3, 0))
 
     def test_yield(self):
-        source = "yield"
+        source = "(yield)"
         self.assertAstSourceEqual(source)
         source = textwrap.dedent("""\
         def dummy():
-            yield""")
+            (yield)""")
         self.assertAstSourceEqual(source)
         source = "foo((yield bar))"
+        self.assertAstSourceEqual(source)
+        source = "(yield bar)()"
         self.assertAstSourceEqual(source)
         source = "return (yield from sam())"
         # Probably also works on < 3.4, but doesn't work on 2.7...


### PR DESCRIPTION
It turns out the cheezy way I did yield fixes before was no good, because
it is legal to do (yield foo)(bar).

The new way always encloses yield statements in parentheses.  This is ugly,
and MAY not (I don't know) work on earlier versions, although it works fine
on 2.7.

So it fixes a known bug (behavior actually occurs in a library), but might break < 2.7.  Probably the right thing to do for now.