### PR TITLE
pretty-printing class and function docstrings, fixing #13

### DIFF
--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -148,6 +148,15 @@ class CodegenTestCase(unittest.TestCase):
         source = "return (yield from sam())"
         # Probably also works on < 3.4, but doesn't work on 2.7...
         self.assertAstSourceEqualIfAtLeastVersion(source, (3, 4), (2, 7))
+        
+    def test_pretty_docstring(self):
+        source = textwrap.dedent('''\
+        def my_function():
+            """
+            docstring
+            """
+            return 1''')        
+        self.assertAstSourceEqual(source)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fixes issue #13 with regard to classes and functions; modules still remain to be dealt with. 