### PR TITLE
precedence for `await` and `async for`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ bad.txt
 test_codegen_dump_1.txt
 test_codegen_dump_2.txt
 
+# scratch directory for astor.rtrip
+tmp_rtrip/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/astor/code_gen.py
+++ b/astor/code_gen.py
@@ -612,7 +612,8 @@ class SourceGenerator(ExplicitNodeVisitor):
 
     # new for Python 3.5
     def visit_Await(self, node):
-        self.write('await ', node.value)
+        with self.delimit(node):
+            self.write('await ', node.value)
 
     def visit_Lambda(self, node):
         with self.delimit(node) as delimiters:

--- a/astor/op_util.py
+++ b/astor/op_util.py
@@ -23,6 +23,7 @@ op_data = """
        YieldFrom                0
               If                1
              For                0
+        AsyncFor                0
            While                0
           Return                1
 

--- a/astor/op_util.py
+++ b/astor/op_util.py
@@ -75,6 +75,7 @@ op_data = """
             UAdd   +            0
             USub   -            0
              Pow   **           1
+           Await                1
              Num                1
 """
 

--- a/tests/test_code_gen.py
+++ b/tests/test_code_gen.py
@@ -173,6 +173,12 @@ class CodegenTestCase(unittest.TestCase):
                         return datum"""
         self.assertAstSourceEqualIfAtLeastVersion(source, (3, 5))
 
+    def test_double_await(self):
+        source = """
+            async def foo():
+                return await (await bar())"""
+        self.assertAstSourceEqualIfAtLeastVersion(source, (3, 5))
+
     def test_class_definition_with_starbases_and_kwargs(self):
         source = """
             class TreeFactory(*[FactoryMixin, TreeBase], **{'metaclass': Foo}):


### PR DESCRIPTION
This pull request proposes the addition of two entries to the operator precedence table, and use of the `delimit` context manager in `visit_Await`, to avert errors observed with Python 3.5 (a failing unit test, and a file in the Python source tree failing to roundtrip with `astor.rtrip`).
