### PR TITLE
Added support for a Comment node

### DIFF
--- a/astor/node_util.py
+++ b/astor/node_util.py
@@ -10,6 +10,9 @@ Copyright 2013-2015 (c) Berker Peksag
 Utilities for node (and, by extension, tree) manipulation.
 For a whole-tree approach, see the treewalk submodule.
 
+This module alsoadds some extra nodes which are useful in
+code generation, but do not normally appear in ASTs.
+
 """
 
 import ast
@@ -163,3 +166,7 @@ def allow_ast_comparison():
                 item.__bases__ = tuple(list(item.__bases__) + [CompareHelper])
             except TypeError:
                 pass
+
+
+class Comment(ast.Expr):
+    pass

--- a/astor/source_repr.py
+++ b/astor/source_repr.py
@@ -17,11 +17,11 @@ The goals of the initial cut of this engine are:
 """
 
 
-def pretty_source(source):
+def pretty_source(source, maxline=79):
     """ Prettify the source.
     """
 
-    return ''.join(flatten(split_lines(source)))
+    return ''.join(flatten(split_lines(source, maxline)))
 
 
 def flatten(source, list=list, isinstance=isinstance):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, pypy, pypy3
+envlist = py26, py27, py33, py34, py35, pypy, pypy3
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
Resolves #50 

This new node makes it possible to generate comments consisting of text, as well as comments consisting of AST nodes (which render to commented-out Python source).

So far I have not tested this with multi-line nodes such as function definitions. I'm also not sure it will correctly interact with the `add_line_information` flag. I intend to add more tests in this PR for these things.

The `capture_result` method I've introduced might work better by creating a new SourceGenerator instance and writing into that, then returning the result of it. Please let me know your thoughts on that.
