### PR TITLE
Deprecate old API (issue #59)

### DIFF
--- a/astor/__init__.py
+++ b/astor/__init__.py
@@ -9,6 +9,8 @@ Copyright 2013 (c) Berker Peksag
 
 """
 
+import warnings
+
 from .code_gen import to_source  # NOQA
 from .node_util import iter_node, strip_tree, dump_tree
 from .node_util import ExplicitNodeVisitor
@@ -29,7 +31,7 @@ __version__ = '0.6'
 #      will never be used by other packages, and other
 #      things could be accessed from their submodule.
 
-
+deprecated = """
 get_boolop = get_binop = get_cmpop = get_unaryop = get_op_symbol  # NOQA
 get_anyop = get_op_symbol
 parsefile = code_to_ast.parse_file
@@ -38,3 +40,38 @@ dump = dump_tree
 all_symbols = symbol_data
 treewalk = tree_walk
 codegen = code_gen
+"""
+
+exec(deprecated)
+
+def deprecate():
+    def wrap(deprecated_name, target_name):
+        if '.' in target_name:
+            target_mod, target_fname = target_name.split('.')
+            target_func = getattr(globals()[target_mod], target_fname)
+        else:
+            target_func = globals()[target_name]
+        msg = "astor.%s is deprecated.  Please use astor.%s." % (deprecated_name, target_name)
+        if callable(target_func):
+            def newfunc(*args, **kwarg):
+                warnings.warn(msg, FutureWarning)
+                return target_func(*args, **kwarg)
+        else:
+            class ModProxy:
+                def __getattr__(self, name):
+                    warnings.warn(msg, FutureWarning)
+                    return getattr(target_func, name)
+            newfunc = ModProxy()
+
+        globals()[deprecated_name] = newfunc
+
+    for line in deprecated.splitlines():
+        line = line.split('#')[0].replace('=', '').split()
+        if line:
+            target_name = line.pop()
+            for deprecated_name in line:
+                wrap(deprecated_name, target_name)
+
+deprecate()
+
+del deprecate, deprecated

--- a/tests/test_code_gen.py
+++ b/tests/test_code_gen.py
@@ -409,6 +409,14 @@ class CodegenTestCase(unittest.TestCase):
         for mode in 'exec eval single'.split():
             srcast = compile(code, 'dummy', mode, ast.PyCF_ONLY_AST)
             dsttxt = astor.to_source(srcast)
+            if code.strip() != dsttxt.strip():
+                self.assertEqual('(%s)' % code.strip(), dsttxt.strip())
+
+    def test_deprecation(self):
+        ast1 = astor.code_to_ast.parse_file(__file__)
+        ast2 = astor.parsefile(__file__)
+        self.assertEqual(astor.to_source(ast1), astor.codegen.to_source(ast2))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
DeprecationWarnings don't appear by default, so I used FutureWarning to insure it shows up.

If this is wrong, we can change.