### PR TITLE
Enhance code generator performance

### DIFF
--- a/astor/__init__.py
+++ b/astor/__init__.py
@@ -12,11 +12,11 @@ Copyright 2013 (c) Berker Peksag
 import warnings
 
 from .code_gen import to_source  # NOQA
-from .node_util import iter_node, strip_tree, dump_tree
-from .node_util import ExplicitNodeVisitor
+from .node_util import iter_node, strip_tree, dump_tree  # NOQA
+from .node_util import ExplicitNodeVisitor  # NOQA
 from .file_util import CodeToAst, code_to_ast  # NOQA
 from .op_util import get_op_symbol, get_op_precedence  # NOQA
-from .op_util import symbol_data
+from .op_util import symbol_data  # NOQA
 from .tree_walk import TreeWalk  # NOQA
 
 __version__ = '0.6'
@@ -44,6 +44,7 @@ codegen = code_gen
 
 exec(deprecated)
 
+
 def deprecate():
     def wrap(deprecated_name, target_name):
         if '.' in target_name:
@@ -51,7 +52,8 @@ def deprecate():
             target_func = getattr(globals()[target_mod], target_fname)
         else:
             target_func = globals()[target_name]
-        msg = "astor.%s is deprecated.  Please use astor.%s." % (deprecated_name, target_name)
+        msg = "astor.%s is deprecated.  Please use astor.%s." % (
+            deprecated_name, target_name)
         if callable(target_func):
             def newfunc(*args, **kwarg):
                 warnings.warn(msg, FutureWarning)
@@ -65,12 +67,13 @@ def deprecate():
 
         globals()[deprecated_name] = newfunc
 
-    for line in deprecated.splitlines():
+    for line in deprecated.splitlines():  # NOQA
         line = line.split('#')[0].replace('=', '').split()
         if line:
             target_name = line.pop()
             for deprecated_name in line:
                 wrap(deprecated_name, target_name)
+
 
 deprecate()
 

--- a/astor/code_gen.py
+++ b/astor/code_gen.py
@@ -50,7 +50,7 @@ def to_source(node, indent_with=' ' * 4, add_line_information=False,
                                 pretty_string)
     generator.visit(node)
     generator.result.append('\n')
-    if set(generator.result[0]) == '\n':
+    if set(generator.result[0]) == set('\n'):
         generator.result[0] = ''
     return pretty_source(generator.result)
 

--- a/astor/file_util.py
+++ b/astor/file_util.py
@@ -101,4 +101,5 @@ class CodeToAst(object):
             cache[(fname, obj.lineno)] = obj
         return cache[key]
 
+
 code_to_ast = CodeToAst()

--- a/astor/node_util.py
+++ b/astor/node_util.py
@@ -182,7 +182,8 @@ def fast_compare(tree1, tree2):
     work = [(tree1, tree2)]
     pop = work.pop
     extend = work.extend
-    exception = TypeError
+    # TypeError in cPython, AttributeError in PyPy
+    exception = TypeError, AttributeError
     listlen = list.__len__
     zipl = zip_longest
     type_ = type

--- a/astor/node_util.py
+++ b/astor/node_util.py
@@ -21,7 +21,6 @@ except AttributeError:
     zip_longest = itertools.izip_longest
 
 
-
 class NonExistent(object):
     """This is not the class you are looking for.
     """
@@ -171,6 +170,7 @@ def allow_ast_comparison():
             except TypeError:
                 pass
 
+
 def fast_compare(tree1, tree2):
     """ This is optimized to compare two AST trees for equality.
         It makes several assumptions that are currently true for
@@ -184,12 +184,11 @@ def fast_compare(tree1, tree2):
     extend = work.extend
     # TypeError in cPython, AttributeError in PyPy
     exception = TypeError, AttributeError
-    listlen = list.__len__
     zipl = zip_longest
     type_ = type
     list_ = list
     while work:
-        n1, n2 = work.pop()
+        n1, n2 = pop()
         try:
             f1 = geta(n1, '_fields')
             f2 = geta(n2, '_fields')

--- a/astor/rtrip.py
+++ b/astor/rtrip.py
@@ -78,19 +78,22 @@ import logging
 
 from astor.code_gen import to_source
 from astor.file_util import code_to_ast
-from astor.node_util import allow_ast_comparison, dump_tree, strip_tree
+from astor.node_util import (allow_ast_comparison, dump_tree,
+                             strip_tree, fast_compare)
 
 
 dsttree = 'tmp_rtrip'
 
 
-def convert(srctree, dsttree=dsttree, readonly=False, dumpall=False):
+def convert(srctree, dsttree=dsttree, readonly=False, dumpall=False,
+            ignore_exceptions=False, fullcomp=False):
     """Walk the srctree, and convert/copy all python files
     into the dsttree
 
     """
 
-    allow_ast_comparison()
+    if fullcomp:
+        allow_ast_comparison()
 
     parse_file = code_to_ast.parse_file
     find_py_files = code_to_ast.find_py_files
@@ -134,7 +137,13 @@ def convert(srctree, dsttree=dsttree, readonly=False, dumpall=False):
             badfiles.add(srcfname)
             continue
 
-        dsttxt = to_source(srcast)
+
+        try:
+            dsttxt = to_source(srcast)
+        except:
+            if not ignore_exceptions:
+                raise
+            dsttxt = ''
 
         if not readonly:
             dstfname = os.path.join(dstpath, fname)
@@ -150,12 +159,15 @@ def convert(srctree, dsttree=dsttree, readonly=False, dumpall=False):
             dstast = ast.parse(dsttxt) if readonly else parse_file(dstfname)
         except SyntaxError:
             dstast = []
-        unknown_src_nodes.update(strip_tree(srcast))
-        unknown_dst_nodes.update(strip_tree(dstast))
-        if dumpall or srcast != dstast:
+        if fullcomp:
+            unknown_src_nodes.update(strip_tree(srcast))
+            unknown_dst_nodes.update(strip_tree(dstast))
+            bad = srcast != dstast
+        else:
+            bad = not fast_compare(srcast, dstast)
+        if dumpall or bad:
             srcdump = dump_tree(srcast)
             dstdump = dump_tree(dstast)
-            bad = srcdump != dstdump
             logging.warning('    calculating dump -- %s' %
                             ('bad' if bad else 'OK'))
             if bad:

--- a/astor/rtrip.py
+++ b/astor/rtrip.py
@@ -137,7 +137,6 @@ def convert(srctree, dsttree=dsttree, readonly=False, dumpall=False,
             badfiles.add(srcfname)
             continue
 
-
         try:
             dsttxt = to_source(srcast)
         except:
@@ -241,6 +240,7 @@ def usage(msg):
         If the source is not specified, the entire Python library will be used.
 
         """) % msg)
+
 
 if __name__ == '__main__':
     import textwrap

--- a/astor/source_repr.py
+++ b/astor/source_repr.py
@@ -23,6 +23,7 @@ def pretty_source(source):
 
     return ''.join(split_lines(source))
 
+
 def split_lines(source, maxline=79):
     """Split inputs according to lines.
        If a line is short enough, just yield it.
@@ -141,6 +142,7 @@ def wrap_line(line, maxline=79, result=[], count=count):
         extend(nsg)
         pos += cnsg
 
+
 def split_group(source, pos, maxline):
     """ Split a group into two subgroups.  The
         first will be appended to the current
@@ -207,6 +209,7 @@ def delimiter_groups(line, begin_delim=begin_delim,
             assert not text, text
             break
 
+
 statements = set(['del ', 'return', 'yield ', 'if ', 'while '])
 
 
@@ -250,6 +253,7 @@ def add_parens(line, maxline, indent, statements=statements, count=count):
         groups[-1].append(')')
 
     return [item for group in groups for item in group]
+
 
 # Assignment operators
 ops = list('|^&+-*/%@~') + '<< >> // **'.split() + ['']

--- a/astor/source_repr.py
+++ b/astor/source_repr.py
@@ -21,59 +21,52 @@ def pretty_source(source):
     """ Prettify the source.
     """
 
-    return ''.join(flatten(split_lines(source)))
-
-
-def flatten(source, list=list, isinstance=isinstance):
-    """ Deal with nested lists
-    """
-
-    def flatten_iter(source):
-        for item in source:
-            if isinstance(item, list):
-                for item in flatten_iter(item):
-                    yield item
-            else:
-                yield item
-    return flatten_iter(source)
-
+    return ''.join(split_lines(source))
 
 def split_lines(source, maxline=79):
     """Split inputs according to lines.
        If a line is short enough, just yield it.
        Otherwise, fix it.
     """
+    result = []
+    extend = result.extend
+    append = result.append
     line = []
     multiline = False
     count = 0
+    find = str.find
     for item in source:
-        if item.startswith('\n'):
+        index = find(item, '\n')
+        if index:
+            line.append(item)
+            multiline = index > 0
+            count += len(item)
+        else:
             if line:
                 if count <= maxline or multiline:
-                    yield line
+                    extend(line)
                 else:
-                    for item2 in wrap_line(line, maxline):
-                        yield item2
+                    wrap_line(line, maxline, result)
                 count = 0
                 multiline = False
                 line = []
-            yield item
-        else:
-            line.append(item)
-            multiline = '\n' in item
-            count += len(item)
+            append(item)
+    return result
 
 
-def count(group):
-    return sum(len(x) for x in group)
+def count(group, slen=str.__len__):
+    return sum([slen(x) for x in group])
 
 
-def wrap_line(line, maxline=79, count=count):
+def wrap_line(line, maxline=79, result=[], count=count):
     """ We have a line that is too long,
         so we're going to try to wrap it.
     """
 
     # Extract the indentation
+
+    append = result.append
+    extend = result.extend
 
     indentation = line[0]
     lenfirst = len(indentation)
@@ -100,10 +93,10 @@ def wrap_line(line, maxline=79, count=count):
     # then set up to deal with the remainder in pairs.
 
     first = unsplittable[0]
-    yield indentation
-    yield first
+    append(indentation)
+    extend(first)
     if not splittable:
-        return
+        return result
     pos = indent + count(first)
     indentation += '    '
     indent += 4
@@ -116,8 +109,8 @@ def wrap_line(line, maxline=79, count=count):
             # If we already have stuff on the line and even
             # the very first item won't fit, start a new line
             if pos > indent and pos + len(sg[0]) > maxline:
-                yield '\n'
-                yield indentation
+                append('\n')
+                append(indentation)
                 pos = indent
 
             # Dump lines out of the splittable group
@@ -127,27 +120,26 @@ def wrap_line(line, maxline=79, count=count):
                 ready, sg = split_group(sg, pos, maxline)
                 if ready[-1].endswith(' '):
                     ready[-1] = ready[-1][:-1]
-                yield ready
-                yield '\n'
-                yield indentation
+                extend(ready)
+                append('\n')
+                append(indentation)
                 pos = indent
                 csg = count(sg)
 
             # Dump the remainder of the splittable group
             if sg:
-                yield sg
+                extend(sg)
                 pos += csg
 
         # Dump the unsplittable group, optionally
         # preceded by a linefeed.
         cnsg = count(nsg)
         if pos > indent and pos + cnsg > maxline:
-            yield '\n'
-            yield indentation
+            append('\n')
+            append(indentation)
             pos = indent
-        yield nsg
+        extend(nsg)
         pos += cnsg
-
 
 def split_group(source, pos, maxline):
     """ Split a group into two subgroups.  The

--- a/astor/string_repr.py
+++ b/astor/string_repr.py
@@ -6,7 +6,7 @@ License: 3-clause BSD
 
 Copyright (c) 2015 Patrick Maupin
 
-Pretty-sys.stderr.write strings for the decompiler
+Pretty-print strings for the decompiler
 
 We either return the repr() of the string,
 or try to format it as a triple-quoted string.
@@ -18,8 +18,6 @@ This has lots of Python 2 / Python 3 ugliness.
 """
 
 import re
-import logging
-import sys
 
 try:
     special_unicode = unicode
@@ -41,6 +39,7 @@ def _properly_indented(s, line_indent):
         return False
     counts = [(len(x) - len(x.lstrip())) for x in mylist]
     return counts and min(counts) >= line_indent
+
 
 mysplit = re.compile(r'(\\|\"\"\"|\"$)').split
 replacements = {'\\': '\\\\', '"""': '""\\"', '"': '\\"'}
@@ -104,11 +103,4 @@ def pretty_string(s, embedded, current_line, uni_lit=False,
             return fancy
     except:
         pass
-    """
-    logging.warning("***String conversion did not work\n")
-    #print (eval(fancy), s)
-    print
-    print (fancy, repr(s))
-    print
-    """
     return default

--- a/astor/string_repr.py
+++ b/astor/string_repr.py
@@ -19,6 +19,7 @@ This has lots of Python 2 / Python 3 ugliness.
 
 import re
 import logging
+import sys
 
 try:
     special_unicode = unicode
@@ -37,19 +38,13 @@ def _get_line(current_output):
         find the start of the current line,
         and return the entire line.
     """
-    myline = []
-    index = len(current_output)
-    while index:
-        index -= 1
-        try:
-            s = str(current_output[index])
-        except:
-            raise
-        myline.append(s)
-        if '\n' in s:
+    for index in range(len(current_output) - 1, -1, -1):
+        if '\n' in current_output[index]:
             break
-    myline = ''.join(reversed(myline))
-    return myline.rsplit('\n', 1)[-1]
+
+    myline = current_output[index:]
+    myline[0] = myline[0].rsplit('\n', 1)[-1]
+    return ''.join(myline)
 
 
 def _properly_indented(s, current_line):

--- a/astor/tree_walk.py
+++ b/astor/tree_walk.py
@@ -33,6 +33,7 @@ class MetaFlatten(type):
         # Delegate the real work to type
         return type.__new__(clstype, name, newbases, newdict)
 
+
 MetaFlatten = MetaFlatten('MetaFlatten', (object, ), {})
 
 

--- a/tests/build_expressions.py
+++ b/tests/build_expressions.py
@@ -236,5 +236,6 @@ def makelib():
             f.write(lineend)
         f.write('"""\n'.encode('utf-8'))
 
+
 if __name__ == '__main__':
     makelib()

--- a/tests/check_expressions.py
+++ b/tests/check_expressions.py
@@ -23,10 +23,6 @@ should not be part of the automated regressions.
 """
 
 import sys
-import collections
-import itertools
-import textwrap
-import hashlib
 import ast
 import astor
 
@@ -85,6 +81,7 @@ def checklib():
                         print()
                 f.write(('%s      %s\n' % (repr(srctxt),
                                            repr(dsttxt))).encode('utf-8'))
+
 
 if __name__ == '__main__':
     checklib()

--- a/tests/test_code_gen.py
+++ b/tests/test_code_gen.py
@@ -454,6 +454,11 @@ class CodegenTestCase(unittest.TestCase):
         """
         self.assertAstEqual(source)
 
+    def test_non_string_leakage(self):
+        source = '''
+        tar_compression = {'gzip': 'gz', None: ''}
+        '''
+        self.assertAstEqual(source)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_code_gen.py
+++ b/tests/test_code_gen.py
@@ -365,13 +365,13 @@ class CodegenTestCase(unittest.TestCase):
 
     def test_fstrings(self):
         source = """
-        f'{x}'
-        f'{x.y}'
-        f'{int(x)}'
-        f'a{b:c}d'
-        f'a{b!s:c{d}e}f'
-        f'""'
-        f'"\\''
+        x = f'{x}'
+        x = f'{x.y}'
+        x = f'{int(x)}'
+        x = f'a{b:c}d'
+        x = f'a{b!s:c{d}e}f'
+        x = f'""'
+        x = f'"\\''
         """
         self.assertAstSourceEqualIfAtLeastVersion(source, (3, 6))
         source = """
@@ -459,6 +459,20 @@ class CodegenTestCase(unittest.TestCase):
         tar_compression = {'gzip': 'gz', None: ''}
         '''
         self.assertAstEqual(source)
+
+    def test_fast_compare(self):
+        fast_compare = astor.node_util.fast_compare
+        def check(a, b):
+            ast_a = ast.parse(a)
+            ast_b = ast.parse(b)
+            dump_a = astor.dump_tree(ast_a)
+            dump_b = astor.dump_tree(ast_b)
+            self.assertEqual(dump_a == dump_b, fast_compare(ast_a, ast_b))
+        check('a = 3', 'a = 3')
+        check('a = 3', 'a = 5')
+        check('a = 3 - (3, 4, 5)', 'a = 3 - (3, 4, 5)')
+        check('a = 3 - (3, 4, 5)', 'a = 3 - (3, 4, 6)')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_code_gen.py
+++ b/tests/test_code_gen.py
@@ -343,10 +343,10 @@ class CodegenTestCase(unittest.TestCase):
         source = """
             __all__ = ['ArgumentParser', 'ArgumentError', 'ArgumentTypeError',
                 'FileType', 'HelpFormatter', 'ArgumentDefaultsHelpFormatter',
-                'RawDescriptionHelpFormatter', 'RawTextHelpFormatter', 'Namespace',  # NOQA
-                'Action', 'ONE_OR_MORE', 'OPTIONAL', 'PARSER', 'REMAINDER', 'SUPPRESS',  # NOQA
+                'RawDescriptionHelpFormatter', 'RawTextHelpFormatter', 'Namespace',
+                'Action', 'ONE_OR_MORE', 'OPTIONAL', 'PARSER', 'REMAINDER', 'SUPPRESS',
                 'ZERO_OR_MORE']
-        """
+        """  # NOQA
         self.maxDiff = 2000
         self.assertAstSourceEqual(source)
 

--- a/tests/test_code_gen.py
+++ b/tests/test_code_gen.py
@@ -343,11 +343,11 @@ class CodegenTestCase(unittest.TestCase):
         source = """
             __all__ = ['ArgumentParser', 'ArgumentError', 'ArgumentTypeError',
                 'FileType', 'HelpFormatter', 'ArgumentDefaultsHelpFormatter',
-                'RawDescriptionHelpFormatter', 'RawTextHelpFormatter', 'Namespace',
-                'Action', 'ONE_OR_MORE', 'OPTIONAL', 'PARSER', 'REMAINDER', 'SUPPRESS',
+                'RawDescriptionHelpFormatter', 'RawTextHelpFormatter', 'Namespace',  # NOQA
+                'Action', 'ONE_OR_MORE', 'OPTIONAL', 'PARSER', 'REMAINDER', 'SUPPRESS',  # NOQA
                 'ZERO_OR_MORE']
         """
-        self.maxDiff=2000
+        self.maxDiff = 2000
         self.assertAstSourceEqual(source)
 
     def test_elif(self):
@@ -384,7 +384,6 @@ class CodegenTestCase(unittest.TestCase):
         """
         self.assertAstSourceEqualIfAtLeastVersion(source, (3, 6))
 
-
     def test_annassign(self):
         source = """
             a: int
@@ -402,7 +401,6 @@ class CodegenTestCase(unittest.TestCase):
             a.b: int = 0
         """
         self.assertAstEqualIfAtLeastVersion(source, (3, 6))
-
 
     def test_compile_types(self):
         code = '(a + b + c) * (d + e + f)\n'
@@ -462,6 +460,7 @@ class CodegenTestCase(unittest.TestCase):
 
     def test_fast_compare(self):
         fast_compare = astor.node_util.fast_compare
+
         def check(a, b):
             ast_a = ast.parse(a)
             ast_b = ast.parse(b)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -16,5 +16,6 @@ class GetSymbolTestCase(unittest.TestCase):
     def test_get_mat_mult(self):
         self.assertEqual('@', astor.get_op_symbol(ast.MatMult()))
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Algorithmic gains in pretty printer
- Huge gains from using lists instead of generators in string prettifier
- Diminishing gains from a few closures in code_gen
- One code-gen fix (and a test case) for None leaking into code-gen result list.
- Even larger gains to be had in node_util for tree scrubbing, etc., but not now

Overall, when running rtrip on the 3.6 stdlib, this reduces the time spent in code generation by 40%, for an overall gain of 23%.  There is lots of room for improvement in node_util (for the scrubbing, comparison, and dumping, not for the code generation), but I'm not willing to do that at the moment.

**edited**:  Found even more gains in the strings, and created a fast comparison in node_util for rtrip.  rtrip is much faster now.