### PR TITLE
Fix new deprecation warnings

### DIFF
--- a/astor/__init__.py
+++ b/astor/__init__.py
@@ -54,12 +54,12 @@ def deprecate():
         msg = "astor.%s is deprecated.  Please use astor.%s." % (deprecated_name, target_name)
         if callable(target_func):
             def newfunc(*args, **kwarg):
-                warnings.warn(msg, FutureWarning)
+                warnings.warn(msg, DeprecationWarning, stacklevel=2)
                 return target_func(*args, **kwarg)
         else:
             class ModProxy:
                 def __getattr__(self, name):
-                    warnings.warn(msg, FutureWarning)
+                    warnings.warn(msg, DeprecationWarning, stacklevel=2)
                     return getattr(target_func, name)
             newfunc = ModProxy()
 

--- a/tests/test_code_gen.py
+++ b/tests/test_code_gen.py
@@ -414,8 +414,12 @@ class CodegenTestCase(unittest.TestCase):
 
     def test_deprecation(self):
         ast1 = astor.code_to_ast.parse_file(__file__)
-        ast2 = astor.parsefile(__file__)
-        self.assertEqual(astor.to_source(ast1), astor.codegen.to_source(ast2))
+        src1 = astor.to_source(ast1)
+        with self.assertWarns(DeprecationWarning):
+            ast2 = astor.parsefile(__file__)
+        with self.assertWarns(DeprecationWarning):
+            src2 = astor.codegen.to_source(ast2)
+        self.assertEqual(src1, src2)
 
     def test_unicode_literals(self):
         source = """

--- a/tests/test_code_gen.py
+++ b/tests/test_code_gen.py
@@ -10,6 +10,7 @@ Copyright (c) 2015 Patrick Maupin
 import ast
 import sys
 import textwrap
+import warnings
 
 try:
     import unittest2 as unittest
@@ -413,13 +414,26 @@ class CodegenTestCase(unittest.TestCase):
                 self.assertEqual('(%s)' % code.strip(), dsttxt.strip())
 
     def test_deprecation(self):
-        ast1 = astor.code_to_ast.parse_file(__file__)
-        src1 = astor.to_source(ast1)
-        with self.assertWarns(DeprecationWarning):
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always")
+            ast1 = astor.code_to_ast.parse_file(__file__)
+            src1 = astor.to_source(ast1)
             ast2 = astor.parsefile(__file__)
-        with self.assertWarns(DeprecationWarning):
             src2 = astor.codegen.to_source(ast2)
+            self.assertEqual(len(w), 2)
+            w = [warnings.formatwarning(x.message, x.category,
+                                        x.filename, x.lineno) for x in w]
+            w = [x.rsplit(':', 1)[-1].strip() for x in w]
+            self.assertEqual(w[0], 'astor.parsefile is deprecated.  '
+                             'Please use astor.code_to_ast.parse_file.\n'
+                             '  ast2 = astor.parsefile(__file__)')
+            self.assertEqual(w[1], 'astor.codegen is deprecated.  '
+                             'Please use astor.code_gen.\n'
+                             '  src2 = astor.codegen.to_source(ast2)')
+
         self.assertEqual(src1, src2)
+
 
     def test_unicode_literals(self):
         source = """


### PR DESCRIPTION
  - Change to DeprecationWarning to reduce noise in other testers
  - Set stack level so warning appears with proper source line
  - Check for warning in test