### PR TITLE
Link to Read The Docs with working SSL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ astor -- AST observe/rewrite
 =============================
 
 :PyPI: https://pypi.python.org/pypi/astor
-:Documentation: https://astor.rtfd.org/
+:Documentation: https://astor.readthedocs.io
 :Source: https://github.com/berkerpeksag/astor
 :License: 3-clause BSD
 :Build status:


### PR DESCRIPTION
The domain astor.rtfd.org doesn't matched the certificate that is being served. so the documentation link resulted in a browser warning, rather than the docs.