### PR TITLE
Support python 3.7 docstrings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ python:
 matrix:
   allow_failures:
   - python: 2.6
-  - python: 3.7-dev
 cache: pip
 install:
   - pip install tox-travis

--- a/astor/code_gen.py
+++ b/astor/code_gen.py
@@ -22,7 +22,7 @@ import sys
 
 from .op_util import get_op_symbol, get_op_precedence, Precedence
 from .node_util import ExplicitNodeVisitor
-from .string_repr import pretty_string
+from .string_repr import pretty_string, _prep_triple_quotes
 from .source_repr import pretty_source
 
 
@@ -226,6 +226,32 @@ class SourceGenerator(ExplicitNodeVisitor):
         self.body(node.body)
         self.else_body(node.orelse)
 
+    def docstring(self, node, indent=1):
+        """
+        Write the function/module/class docstring attribute
+
+        This method has an effect only for python >= 3.7 . For python earlier
+        versions the docstring was represented as the first expression in the
+        function/module/class body.
+
+        Args:
+            node (ast.AST): The node whose docstring is printed.
+            indent (int): How much to indent the docstring (usually is 0 for
+                ast.Module, and 1 for ast.FunctionDef, ast.AsyncFunctionDef and
+                ast.ClassDef).
+        """
+        if not sys.version_info >= (3, 7):
+            return
+
+        value = getattr(node, 'docstring', None)
+        if value is None:
+            return
+
+        self.newline()
+        self.indentation += indent
+        self.write('"""%s"""' % _prep_triple_quotes(value))
+        self.indentation -= indent
+
     def visit_arguments(self, node):
         want_comma = []
 
@@ -316,6 +342,7 @@ class SourceGenerator(ExplicitNodeVisitor):
         self.write(')')
         self.conditional_write(' ->', self.get_returns(node))
         self.write(':')
+        self.docstring(node)
         self.body(node.body)
         if not self.indentation:
             self.newline(extra=2)
@@ -345,6 +372,7 @@ class SourceGenerator(ExplicitNodeVisitor):
         self.conditional_write(paren_or_comma, '*', self.get_starargs(node))
         self.conditional_write(paren_or_comma, '**', self.get_kwargs(node))
         self.write(have_args and '):' or ':')
+        self.docstring(node)
         self.body(node.body)
         if not self.indentation:
             self.newline(extra=2)
@@ -776,6 +804,7 @@ class SourceGenerator(ExplicitNodeVisitor):
             self.visit(node.value)
 
     def visit_Module(self, node):
+        self.docstring(node, indent=0)
         self.write(*node.body)
 
     visit_Interactive = visit_Module

--- a/astor/code_gen.py
+++ b/astor/code_gen.py
@@ -22,7 +22,7 @@ import sys
 
 from .op_util import get_op_symbol, get_op_precedence, Precedence
 from .node_util import ExplicitNodeVisitor
-from .string_repr import pretty_string, _prep_triple_quotes
+from .string_repr import pretty_string, string_triplequote_repr
 from .source_repr import pretty_source
 
 
@@ -249,7 +249,7 @@ class SourceGenerator(ExplicitNodeVisitor):
 
         self.newline()
         self.indentation += indent
-        self.write('"""%s"""' % _prep_triple_quotes(value))
+        self.write(string_triplequote_repr(value))
         self.indentation -= indent
 
     def visit_arguments(self, node):

--- a/astor/code_gen.py
+++ b/astor/code_gen.py
@@ -228,9 +228,9 @@ class SourceGenerator(ExplicitNodeVisitor):
 
     def docstring(self, node, indent=1):
         """
-        Write the function/module/class docstring attribute
+        Write the function/module/class docstring attribute.
 
-        This method has an effect only for python >= 3.7 . For python earlier
+        This method has an effect only for python >= 3.7. For python earlier
         versions the docstring was represented as the first expression in the
         function/module/class body.
 
@@ -240,7 +240,7 @@ class SourceGenerator(ExplicitNodeVisitor):
                 ast.Module, and 1 for ast.FunctionDef, ast.AsyncFunctionDef and
                 ast.ClassDef).
         """
-        if not sys.version_info >= (3, 7):
+        if sys.version_info < (3, 7):
             return
 
         value = getattr(node, 'docstring', None)

--- a/astor/string_repr.py
+++ b/astor/string_repr.py
@@ -55,6 +55,12 @@ def _prep_triple_quotes(s, mysplit=mysplit, replacements=replacements):
     return ''.join(s)
 
 
+def string_triplequote_repr(s):
+    """Return string's python representation in triple quotes.
+    """
+    return '"""%s"""' % _prep_triple_quotes(s)
+
+
 def pretty_string(s, embedded, current_line, uni_lit=False,
                   min_trip_str=20, max_line=100):
     """There are a lot of reasons why we might not want to or
@@ -91,7 +97,7 @@ def pretty_string(s, embedded, current_line, uni_lit=False,
         if total_len < max_line and not _properly_indented(s, line_indent):
             return default
 
-    fancy = '"""%s"""' % _prep_triple_quotes(s)
+    fancy = string_triplequote_repr(s)
 
     # Sometimes this doesn't work.  One reason is that
     # the AST has no understanding of whether \r\n was

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -30,7 +30,12 @@ Bug fixes
   (Reported by Felix Yan and contributed by Radomír Bosák in
   `Issue 89`_.)
 
+* Fixed docstring generation for Python 3.7+
+  (Reported by Kodi Arfer and contributed by Radomír Bosák in
+  `Issue 101`_.)
+
 .. _`Issue 89`: https://github.com/berkerpeksag/astor/issues/89
+.. _`Issue 101`: https://github.com/berkerpeksag/astor/issues/101
 
 
 0.6.2 - 2017-11-11

--- a/tests/test_code_gen.py
+++ b/tests/test_code_gen.py
@@ -482,13 +482,49 @@ class CodegenTestCase(unittest.TestCase, Comparisons):
         '''
         self.assertSrcRoundtripsGtVer(source, (3, 6))
 
-    def test_docstring(self):
+    def test_docstring_function(self):
         source = '''
         def f(arg):
             """
             docstring
             """
             return 3
+        '''
+        self.assertSrcRoundtrips(source)
+
+    def test_docstring_class(self):
+        source = '''
+        class Class:
+            """
+            docstring
+            """
+            pass
+        '''
+        self.assertSrcRoundtrips(source)
+
+    def test_docstring_method(self):
+        source = '''
+        class Class:
+
+            def f(arg):
+                """
+                docstring
+                """
+                return 3
+        '''
+        self.assertSrcRoundtrips(source)
+
+    def test_docstring_module(self):
+        source = '''
+        """
+        docstring1
+        """
+
+
+        class Class:
+
+            def f(arg):
+                pass
         '''
         self.assertSrcRoundtrips(source)
 

--- a/tests/test_code_gen.py
+++ b/tests/test_code_gen.py
@@ -482,6 +482,16 @@ class CodegenTestCase(unittest.TestCase, Comparisons):
         '''
         self.assertSrcRoundtripsGtVer(source, (3, 6))
 
+    def test_docstring(self):
+        source = '''
+        def f(arg):
+            """
+            docstring
+            """
+            return 3
+        '''
+        self.assertSrcRoundtrips(source)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This fixes the change in python API introduced by
https://bugs.python.org/issue29463

Fixes #101.