### PR TITLE
Fix trailing newlines in f-strings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - 3.5
   - 3.6
   - pypy
-  - pypy3.3-5.2-alpha1
+  - pypy3.5
   - 3.7-dev
 matrix:
   allow_failures:

--- a/AUTHORS
+++ b/AUTHORS
@@ -12,3 +12,4 @@ And with some modifications based on Armin's code:
 * Zack M. Davis <code@zackmdavis.net>
 * Ryan Gonzalez <rymg19@gmail.com>
 * Lenny Truong <leonardtruong@protonmail.com>
+* Radomír Bosák <radomir.bosak@gmail.com>

--- a/astor/code_gen.py
+++ b/astor/code_gen.py
@@ -580,6 +580,9 @@ class SourceGenerator(ExplicitNodeVisitor):
 
             index = len(result)
             recurse(node)
+
+            # Flush trailing newlines (so that they are part of mystr)
+            self.write('')
             mystr = ''.join(result[index:])
             del result[index:]
             self.colinfo = res_index, str_index  # Put it back like we found it

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,6 +27,11 @@ Bug fixes
 
 * Fixed a bug where newlines would be inserted to a wrong place during
   printing f-strings with trailing newlines.
+  (Reported by Felix Yan and contributed by Radomír Bosák in
+  `Issue 89`_.)
+
+.. _`Issue 89`: https://github.com/berkerpeksag/astor/issues/89
+
 
 0.6.2 - 2017-11-11
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,11 @@ New features
 
 .. _`Issue 86`: https://github.com/berkerpeksag/astor/issues/86
 
+Bug fixes
+~~~~~~~~~
+
+* Fixed a bug where newlines would be inserted to a wrong place during
+  printing f-strings with trailing newlines.
 
 0.6.2 - 2017-11-11
 ------------------

--- a/tests/test_code_gen.py
+++ b/tests/test_code_gen.py
@@ -476,6 +476,12 @@ class CodegenTestCase(unittest.TestCase, Comparisons):
         '''
         self.assertAstRoundtrips(source)
 
+    def test_fstring_trailing_newline(self):
+        source = '''
+        x = f"""{host}\n\t{port}\n"""
+        '''
+        self.assertSrcRoundtripsGtVer(source, (3, 6))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, py35, py36, pypy, pypy3.3-5.2-alpha1
+envlist = py26, py27, py33, py34, py35, py36, pypy, pypy3.5
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
If an f-string was ended with a newline character (more precisely, if
the last element of a JoinedStr node was just a newline character), its
round-trip source code representation would have an extra newline on a
wrong place, resulting in invalid syntax.

The bug affects only python>=3.6 (f-strings weren't supported before)

This commit fixes the aforementioned bug.

Fixes #89.