### PR TITLE
Revert Python 3.7 docstring handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
   - 3.6
   - pypy
   - pypy3.5
-  - 3.7-dev
 cache: pip
 install:
   - pip install tox-travis

--- a/astor/code_gen.py
+++ b/astor/code_gen.py
@@ -227,32 +227,6 @@ class SourceGenerator(ExplicitNodeVisitor):
         self.body(node.body)
         self.else_body(node.orelse)
 
-    def docstring(self, node, indent=1):
-        """
-        Write the function/module/class docstring attribute.
-
-        This method has an effect only for python >= 3.7. For python earlier
-        versions the docstring was represented as the first expression in the
-        function/module/class body.
-
-        Args:
-            node (ast.AST): The node whose docstring is printed.
-            indent (int): How much to indent the docstring (usually is 0 for
-                ast.Module, and 1 for ast.FunctionDef, ast.AsyncFunctionDef and
-                ast.ClassDef).
-        """
-        if sys.version_info < (3, 7):
-            return
-
-        value = getattr(node, 'docstring', None)
-        if value is None:
-            return
-
-        self.newline()
-        self.indentation += indent
-        self.write(string_triplequote_repr(value))
-        self.indentation -= indent
-
     def visit_arguments(self, node):
         want_comma = []
 
@@ -343,7 +317,6 @@ class SourceGenerator(ExplicitNodeVisitor):
         self.write(')')
         self.conditional_write(' ->', self.get_returns(node))
         self.write(':')
-        self.docstring(node)
         self.body(node.body)
         if not self.indentation:
             self.newline(extra=2)
@@ -373,7 +346,6 @@ class SourceGenerator(ExplicitNodeVisitor):
         self.conditional_write(paren_or_comma, '*', self.get_starargs(node))
         self.conditional_write(paren_or_comma, '**', self.get_kwargs(node))
         self.write(have_args and '):' or ':')
-        self.docstring(node)
         self.body(node.body)
         if not self.indentation:
             self.newline(extra=2)
@@ -821,7 +793,6 @@ class SourceGenerator(ExplicitNodeVisitor):
             self.visit(node.value)
 
     def visit_Module(self, node):
-        self.docstring(node, indent=0)
         self.write(*node.body)
 
     visit_Interactive = visit_Module

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -33,12 +33,7 @@ Bug fixes
   (Reported by Felix Yan and contributed by Radomír Bosák in
   `Issue 89`_.)
 
-* Fixed docstring generation for Python 3.7+
-  (Reported by Kodi Arfer and contributed by Radomír Bosák in
-  `Issue 101`_.)
-
 .. _`Issue 89`: https://github.com/berkerpeksag/astor/issues/89
-.. _`Issue 101`: https://github.com/berkerpeksag/astor/issues/101
 
 * Improved code generation to support ``ast.Num`` nodes containing infinities
   or NaNs.


### PR DESCRIPTION
Closes #106.

I tested this on CPython commit 1d419faccdaae27d968cef1e1ece6b9374694573.