### PR TITLE
Extract ASTs from methods and nested functions

### DIFF
--- a/astor/file_util.py
+++ b/astor/file_util.py
@@ -101,15 +101,15 @@ class CodeToAst(object):
             ast.If,
             ast.For,
             ast.While,
-            ast.Try,
             ast.ExceptHandler,
             ast.With,
             ast.ClassDef,
             ast.FunctionDef,
         ]
-        for async_node in ["AsyncFunctionDef", "AsyncFor", "AsyncWith"]:
+        version_specific_nodes = ["AsyncFunctionDef", "AsyncFor", "AsyncWith", "Try"]
+        for version_specific_node in version_specific_nodes:
             try:
-                node = getattr(ast, async_node)
+                node = getattr(ast, version_specific_node)
             except AttributeError:
                 continue
             else:

--- a/astor/file_util.py
+++ b/astor/file_util.py
@@ -94,8 +94,9 @@ class CodeToAst(object):
         self.cache = cache or {}
         self.func_types = [
             ast.FunctionDef,
-            ast.AsyncFunctionDef,
         ]
+        if hasattr(ast, "AsyncFunctionDef"):
+            self.func_types.append(ast.AsyncFunctionDef)
         self.block_types = [
             ast.If,
             ast.For,
@@ -105,10 +106,14 @@ class CodeToAst(object):
             ast.With,
             ast.ClassDef,
             ast.FunctionDef,
-            ast.AsyncFunctionDef,
-            ast.AsyncFor,
-            ast.AsyncWith,
         ]
+        for async_node in ["AsyncFunctionDef", "AsyncFor", "AsyncWith"]:
+            try:
+                node = getattr(ast, async_node)
+            except AttributeError:
+                continue
+            else:
+                self.block_types.append(node)
 
     def _find_funcs(self, filename, parent_ast):
         cache = self.cache

--- a/tests/test_nested_func_detection.py
+++ b/tests/test_nested_func_detection.py
@@ -1,0 +1,28 @@
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+import astor
+
+
+class DummyClass:
+
+    def __init__(self):
+        self.x = 0
+
+    def foo(self):
+
+        def bar():
+            return self.x
+
+        return bar
+
+
+class NestedFunctionTestCase(unittest.TestCase):
+
+    def test_can_locate_method(self):
+        dummy = DummyClass()
+        _ = astor.code_to_ast(dummy.__init__)
+        _ = astor.code_to_ast(dummy.foo())
+


### PR DESCRIPTION
Previously ASTs could be extracted only for bare functions. By
recursively searching "blocks" for function definitions, methods and
nested functions can be located. In this context a "block" is generally
an `ast.AST` subclass with a `body` field, such as `ast.ClassDef` and
`ast.FunctionDef`. Several other nodes such as `ast.If`, `ast.For`, etc
are also searched. See `CodeToAst.block_types` for the complete list.