### PR TITLE
unittest.TestCase.assertWarns introduced in Python 3.2

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -24,6 +24,8 @@ class PublicAPITestCase(unittest.TestCase):
     def test_aliases(self):
         self.assertIs(astor.parse_file, astor.code_to_ast.parse_file)
 
+    @unittest.skipUnless(sys.version_info >= (3, 2),
+                         "TestCase.assertWarns introduced in Python 3.2")
     def test_codegen_from_root(self):
         with self.assertWarns(DeprecationWarning) as cm:
             astor = import_fresh_module('astor')
@@ -35,6 +37,8 @@ class PublicAPITestCase(unittest.TestCase):
             'astor.codegen is deprecated.  Please use astor.code_gen.'
         )
 
+    @unittest.skipUnless(sys.version_info >= (3, 2),
+                         "TestCase.assertWarns introduced in Python 3.2")
     def test_codegen_as_submodule(self):
         with self.assertWarns(DeprecationWarning) as cm:
             import astor.codegen


### PR DESCRIPTION
Unit tests currently fails to run on Python 2.7 because unittest.TestCase.assertWarns does not exist.

This PR disable two test using assertWarns on python << 3.2.

 https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertWarns