### PR TITLE
Handle new ast.Constant node in SourceGenerator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ matrix:
   - python: 3.7
     sudo: required
     dist: xenial
+  - python: 3.8-dev
+    sudo: required
+    dist: xenial
 cache: pip
 install:
   - pip install tox-travis

--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ And with some modifications based on Armin's code:
 * Lenny Truong <leonardtruong@protonmail.com>
 * Radomír Bosák <radomir.bosak@gmail.com>
 * Kodi Arfer <git@arfer.net>
+* Chris Rink <chrisrink10@gmail.com>

--- a/astor/code_gen.py
+++ b/astor/code_gen.py
@@ -539,16 +539,16 @@ class SourceGenerator(ExplicitNodeVisitor):
         if isinstance(value, (float, complex)):
             self._handle_numeric_constant(value)
         elif isinstance(value, str):
-            self._handle_string_constant(node)
+            self._handle_string_constant(node, node.value)
         elif value is Ellipsis:
             self.write('...')
         else:
             self.write(repr(value))
 
     def visit_JoinedStr(self, node):
-        self._handle_string_constant(node, is_joined=True)
+        self._handle_string_constant(node, None, is_joined=True)
 
-    def _handle_string_constant(self, node, is_joined=False):
+    def _handle_string_constant(self, node, value, is_joined=False):
         # embedded is used to control when we might want
         # to use a triple-quoted string.  We determine
         # if we are in an assignment and/or in an expression
@@ -607,13 +607,8 @@ class SourceGenerator(ExplicitNodeVisitor):
             uni_lit = False  # No formatted byte strings
 
         else:
-            if isinstance(node, ast.Str):
-                mystr = node.s
-            elif has_ast_constant and isinstance(node, ast.Constant):
-                mystr = node.value
-            else:
-                kind = type(node).__name__
-                assert False, 'Invalid string node type %s' % kind
+            assert value is not None, "Node value cannot be None"
+            mystr = value
             uni_lit = self.using_unicode_literals
 
         mystr = self.pretty_string(mystr, embedded, current_line, uni_lit)
@@ -629,7 +624,7 @@ class SourceGenerator(ExplicitNodeVisitor):
 
     # deprecated in Python 3.8
     def visit_Str(self, node):
-        self._handle_string_constant(node)
+        self._handle_string_constant(node, node.s)
 
     # deprecated in Python 3.8
     def visit_Bytes(self, node):

--- a/astor/code_gen.py
+++ b/astor/code_gen.py
@@ -642,7 +642,7 @@ class SourceGenerator(ExplicitNodeVisitor):
             self.colinfo = len(result) - 1, lf
 
     # deprecated in Python 3.8
-    def visit_Str(self, node, is_joined=False):
+    def visit_Str(self, node):
         precedence = self.get__pp(node)
         self._handle_string_constant(node.s, precedence)
 

--- a/astor/code_gen.py
+++ b/astor/code_gen.py
@@ -538,10 +538,10 @@ class SourceGenerator(ExplicitNodeVisitor):
     # ast.Ellipsis, ast.NameConstant, ast.Num, ast.Str in Python 3.8
     def visit_Constant(self, node):
         value = node.value
-        if isinstance(value, (complex, float, int)):
-            self._handle_numeric_constant(value)
-        elif isinstance(value, (bool, type(None))):
+        if isinstance(value, (bool, type(None))):
             self._handle_name_constant(value)
+        elif isinstance(value, (complex, float, int)):
+            self._handle_numeric_constant(value)
         elif isinstance(value, str):
             precedence = self.get__pp(node)
             self._handle_string_constant(value, precedence)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,7 +10,10 @@ New features
 
 * Support ``ast.Constant`` nodes being emitted by Python 3.8 (and initially
   created in Python 3.6).
-  (Reported and fixed by Chris Rink in `Issue 120`_.)
+  (Reported and fixed by Chris Rink in `Issue 120`_ and `PR 121`_.)
+
+.. _`Issue 120`: https://github.com/berkerpeksag/astor/issues/120
+.. _`PR 121`: https://github.com/berkerpeksag/astor/pull/121
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,7 +8,9 @@ Release Notes
 New features
 ~~~~~~~~~~~~
 
-*
+* Support ``ast.Constant`` nodes being emitted by Python 3.8 (and initially
+  created in Python 3.6).
+  (Reported and fixed by Chris Rink in `Issue 120`_.)
 
 Bug fixes
 ~~~~~~~~~

--- a/tests/test_code_gen.py
+++ b/tests/test_code_gen.py
@@ -442,6 +442,45 @@ class CodegenTestCase(unittest.TestCase, Comparisons):
         """
         self.assertSrcRoundtripsGtVer(source, (3, 6))
 
+    @unittest.skipIf(sys.version_info >= (3, 8),
+                     "ast.Bytes, ast.Ellipsis, ast.NameConstant, ast.Num, and ast.Str deprecated in Python 3.8")
+    def test_deprecated_constant_nodes(self):
+        tree = ast.Num(3)
+        source = "3"
+        self.assertEqual(self.to_source(tree).rstrip(), source)
+
+        tree = ast.Num(-93)
+        source = "-93"
+        self.assertEqual(self.to_source(tree).rstrip(), source)
+
+        tree = ast.Num(837.3888)
+        source = "837.3888"
+        self.assertEqual(self.to_source(tree).rstrip(), source)
+
+        tree = ast.Num(-0.9877)
+        source = "-0.9877"
+        self.assertEqual(self.to_source(tree).rstrip(), source)
+
+        tree = ast.NameConstant(value=True)
+        source = "True"
+        self.assertEqual(self.to_source(tree).rstrip(), source)
+
+        tree = ast.NameConstant(value=False)
+        source = "False"
+        self.assertEqual(self.to_source(tree).rstrip(), source)
+
+        tree = ast.NameConstant(value=None)
+        source = "None"
+        self.assertEqual(self.to_source(tree).rstrip(), source)
+
+        tree = ast.Ellipsis()
+        source = "..."
+        self.assertEqual(self.to_source(tree).rstrip(), source)
+
+        tree = ast.Str("String")
+        source = '"String"'
+        self.assertEqual(self.to_source(tree).rstrip(), source)
+
     @unittest.skipUnless(sys.version_info >= (3, 6),
                          "ast.Constant introduced in Python 3.6")
     def test_constant_nodes(self):

--- a/tests/test_code_gen.py
+++ b/tests/test_code_gen.py
@@ -442,6 +442,45 @@ class CodegenTestCase(unittest.TestCase, Comparisons):
         """
         self.assertSrcRoundtripsGtVer(source, (3, 6))
 
+    @unittest.skipUnless(sys.version_info >= (3, 6),
+                         "ast.Constant introduced in Python 3.6")
+    def test_constant_nodes(self):
+        tree = ast.Constant(value=3)
+        source = "3"
+        self.assertEqual(self.to_source(tree).rstrip(), source)
+
+        tree = ast.Constant(value=-93)
+        source = "-93"
+        self.assertEqual(self.to_source(tree).rstrip(), source)
+
+        tree = ast.Constant(value=837.3888)
+        source = "837.3888"
+        self.assertEqual(self.to_source(tree).rstrip(), source)
+
+        tree = ast.Constant(value=-0.9877)
+        source = "-0.9877"
+        self.assertEqual(self.to_source(tree).rstrip(), source)
+
+        tree = ast.Constant(value=True)
+        source = "True"
+        self.assertEqual(self.to_source(tree).rstrip(), source)
+
+        tree = ast.Constant(value=False)
+        source = "False"
+        self.assertEqual(self.to_source(tree).rstrip(), source)
+
+        tree = ast.Constant(value=None)
+        source = "None"
+        self.assertEqual(self.to_source(tree).rstrip(), source)
+
+        tree = ast.Constant(value=Ellipsis)
+        source = "..."
+        self.assertEqual(self.to_source(tree).rstrip(), source)
+
+        tree = ast.Constant(value="String")
+        source = '"String"'
+        self.assertEqual(self.to_source(tree).rstrip(), source)
+
     def test_annassign(self):
         source = """
             a: int

--- a/tests/test_code_gen.py
+++ b/tests/test_code_gen.py
@@ -38,6 +38,9 @@ class Comparisons(object):
         dmp2 = astor.dump_tree(ast2)
         self.assertEqual(dmp1, dmp2)
 
+    def assertAstEqualsSource(self, tree, source):
+        self.assertEqual(self.to_source(tree).rstrip(), source)
+
     def assertAstRoundtrips(self, srctxt):
         """This asserts that the reconstituted source
            code can be compiled into the exact same AST
@@ -445,107 +448,103 @@ class CodegenTestCase(unittest.TestCase, Comparisons):
     @unittest.skipUnless(sys.version_info <= (3, 3),
                          "ast.Name used for True, False, None until Python 3.4")
     def test_deprecated_constants_as_name(self):
-        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Name(id='True'))
-        source = "spam = True"
-        self.assertEqual(self.to_source(tree).rstrip(), source)
+        self.assertAstEqualsSource(
+            ast.Assign(targets=[ast.Name(id='spam')], value=ast.Name(id='True')),
+            "spam = True")
 
-        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Name(id='False'))
-        source = "spam = False"
-        self.assertEqual(self.to_source(tree).rstrip(), source)
+        self.assertAstEqualsSource(
+            ast.Assign(targets=[ast.Name(id='spam')], value=ast.Name(id='False')),
+            "spam = False")
 
-        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Name(id='None'))
-        source = "spam = None"
-        self.assertEqual(self.to_source(tree).rstrip(), source)
+        self.assertAstEqualsSource(
+            ast.Assign(targets=[ast.Name(id='spam')], value=ast.Name(id='None')),
+            "spam = None")
 
     @unittest.skipUnless((3, 4) <= sys.version_info <= (3, 8),
                          "ast.NameConstant introduced in Python 3.4, deprecated in 3.8")
     def test_deprecated_name_constants(self):
-        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.NameConstant(value=True))
-        source = "spam = True"
-        self.assertEqual(self.to_source(tree).rstrip(), source)
+        self.assertAstEqualsSource(
+            ast.Assign(targets=[ast.Name(id='spam')], value=ast.NameConstant(value=True)),
+            "spam = True")
 
-        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.NameConstant(value=False))
-        source = "spam = False"
-        self.assertEqual(self.to_source(tree).rstrip(), source)
+        self.assertAstEqualsSource(
+            ast.Assign(targets=[ast.Name(id='spam')], value=ast.NameConstant(value=False)),
+            "spam = False")
 
-        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.NameConstant(value=None))
-        source = "spam = None"
-        self.assertEqual(self.to_source(tree).rstrip(), source)
+        self.assertAstEqualsSource(
+            ast.Assign(targets=[ast.Name(id='spam')], value=ast.NameConstant(value=None)),
+            "spam = None")
 
     @unittest.skipIf(sys.version_info >= (3, 8),
                      "ast.Bytes, ast.Ellipsis, ast.Num, and ast.Str deprecated in Python 3.8")
     def test_deprecated_constant_nodes(self):
-        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Num(3))
-        source = "spam = 3"
-        self.assertEqual(self.to_source(tree).rstrip(), source)
+        self.assertAstEqualsSource(
+            ast.Assign(targets=[ast.Name(id='spam')], value=ast.Num(3)),
+            "spam = 3")
 
-        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Num(-93))
-        source = "spam = -93"
-        self.assertEqual(self.to_source(tree).rstrip(), source)
+        self.assertAstEqualsSource(
+            ast.Assign(targets=[ast.Name(id='spam')], value=ast.Num(-93)),
+            "spam = -93")
 
-        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Num(837.3888))
-        source = "spam = 837.3888"
-        self.assertEqual(self.to_source(tree).rstrip(), source)
+        self.assertAstEqualsSource(
+            ast.Assign(targets=[ast.Name(id='spam')], value=ast.Num(837.3888)),
+            "spam = 837.3888")
 
-        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Num(-0.9877))
-        source = "spam = -0.9877"
-        self.assertEqual(self.to_source(tree).rstrip(), source)
+        self.assertAstEqualsSource(
+            ast.Assign(targets=[ast.Name(id='spam')], value=ast.Num(-0.9877)),
+            "spam = -0.9877")
 
-        tree = ast.Ellipsis()
-        source = "..."
-        self.assertEqual(self.to_source(tree).rstrip(), source)
+        self.assertAstEqualsSource(ast.Ellipsis(), "...")
 
         if sys.version_info >= (3, 0):
-            tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Bytes(b"Bytes"))
-            source = "spam = b'Bytes'"
-            self.assertEqual(self.to_source(tree).rstrip(), source)
+            self.assertAstEqualsSource(
+                ast.Assign(targets=[ast.Name(id='spam')], value=ast.Bytes(b"Bytes")),
+                "spam = b'Bytes'")
 
-        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Str("String"))
-        source = "spam = 'String'"
-        self.assertEqual(self.to_source(tree).rstrip(), source)
+        self.assertAstEqualsSource(
+            ast.Assign(targets=[ast.Name(id='spam')], value=ast.Str("String")),
+            "spam = 'String'")
 
     @unittest.skipUnless(sys.version_info >= (3, 6),
                          "ast.Constant introduced in Python 3.6")
     def test_constant_nodes(self):
-        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Constant(value=3))
-        source = "spam = 3"
-        self.assertEqual(self.to_source(tree).rstrip(), source)
+        self.assertAstEqualsSource(
+            ast.Assign(targets=[ast.Name(id='spam')], value=ast.Constant(value=3)),
+            "spam = 3")
 
-        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Constant(value=-93))
-        source = "spam = -93"
-        self.assertEqual(self.to_source(tree).rstrip(), source)
+        self.assertAstEqualsSource(
+            ast.Assign(targets=[ast.Name(id='spam')], value=ast.Constant(value=-93)),
+            "spam = -93")
 
-        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Constant(value=837.3888))
-        source = "spam = 837.3888"
-        self.assertEqual(self.to_source(tree).rstrip(), source)
+        self.assertAstEqualsSource(
+            ast.Assign(targets=[ast.Name(id='spam')], value=ast.Constant(value=837.3888)),
+            "spam = 837.3888")
 
-        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Constant(value=-0.9877))
-        source = "spam = -0.9877"
-        self.assertEqual(self.to_source(tree).rstrip(), source)
+        self.assertAstEqualsSource(
+            ast.Assign(targets=[ast.Name(id='spam')], value=ast.Constant(value=-0.9877)),
+            "spam = -0.9877")
 
-        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Constant(value=True))
-        source = "spam = True"
-        self.assertEqual(self.to_source(tree).rstrip(), source)
+        self.assertAstEqualsSource(
+            ast.Assign(targets=[ast.Name(id='spam')], value=ast.Constant(value=True)),
+            "spam = True")
 
-        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Constant(value=False))
-        source = "spam = False"
-        self.assertEqual(self.to_source(tree).rstrip(), source)
+        self.assertAstEqualsSource(
+            ast.Assign(targets=[ast.Name(id='spam')], value=ast.Constant(value=False)),
+            "spam = False")
 
-        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Constant(value=None))
-        source = "spam = None"
-        self.assertEqual(self.to_source(tree).rstrip(), source)
+        self.assertAstEqualsSource(
+            ast.Assign(targets=[ast.Name(id='spam')], value=ast.Constant(value=None)),
+            "spam = None")
 
-        tree = ast.Constant(value=Ellipsis)
-        source = "..."
-        self.assertEqual(self.to_source(tree).rstrip(), source)
+        self.assertAstEqualsSource(ast.Constant(value=Ellipsis), "...")
 
-        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Constant(b"Bytes"))
-        source = "spam = b'Bytes'"
-        self.assertEqual(self.to_source(tree).rstrip(), source)
+        self.assertAstEqualsSource(
+            ast.Assign(targets=[ast.Name(id='spam')], value=ast.Constant(b"Bytes")),
+            "spam = b'Bytes'")
 
-        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Constant(value="String"))
-        source = "spam = 'String'"
-        self.assertEqual(self.to_source(tree).rstrip(), source)
+        self.assertAstEqualsSource(
+            ast.Assign(targets=[ast.Name(id='spam')], value=ast.Constant(value="String")),
+            "spam = 'String'")
 
     def test_annassign(self):
         source = """

--- a/tests/test_code_gen.py
+++ b/tests/test_code_gen.py
@@ -460,8 +460,8 @@ class CodegenTestCase(unittest.TestCase, Comparisons):
             ast.Assign(targets=[ast.Name(id='spam')], value=ast.Name(id='None')),
             "spam = None")
 
-    @unittest.skipUnless((3, 4) <= sys.version_info <= (3, 8),
-                         "ast.NameConstant introduced in Python 3.4, deprecated in 3.8")
+    @unittest.skipUnless(sys.version_info >= (3, 4),
+                         "ast.NameConstant introduced in Python 3.4")
     def test_deprecated_name_constants(self):
         self.assertAstEqualsSource(
             ast.Assign(targets=[ast.Name(id='spam')], value=ast.NameConstant(value=True)),
@@ -475,8 +475,6 @@ class CodegenTestCase(unittest.TestCase, Comparisons):
             ast.Assign(targets=[ast.Name(id='spam')], value=ast.NameConstant(value=None)),
             "spam = None")
 
-    @unittest.skipIf(sys.version_info >= (3, 8),
-                     "ast.Bytes, ast.Ellipsis, ast.Num, and ast.Str deprecated in Python 3.8")
     def test_deprecated_constant_nodes(self):
         self.assertAstEqualsSource(
             ast.Assign(targets=[ast.Name(id='spam')], value=ast.Num(3)),

--- a/tests/test_code_gen.py
+++ b/tests/test_code_gen.py
@@ -442,82 +442,109 @@ class CodegenTestCase(unittest.TestCase, Comparisons):
         """
         self.assertSrcRoundtripsGtVer(source, (3, 6))
 
+    @unittest.skipUnless(sys.version_info <= (3, 3),
+                         "ast.Name used for True, False, None until Python 3.4")
+    def test_deprecated_constants_as_name(self):
+        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Name(id='True'))
+        source = "spam = True"
+        self.assertEqual(self.to_source(tree).rstrip(), source)
+
+        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Name(id='False'))
+        source = "spam = False"
+        self.assertEqual(self.to_source(tree).rstrip(), source)
+
+        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Name(id='None'))
+        source = "spam = None"
+        self.assertEqual(self.to_source(tree).rstrip(), source)
+
+    @unittest.skipUnless((3, 4) <= sys.version_info <= (3, 8),
+                         "ast.NameConstant introduced in Python 3.4, deprecated in 3.8")
+    def test_deprecated_name_constants(self):
+        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.NameConstant(value=True))
+        source = "spam = True"
+        self.assertEqual(self.to_source(tree).rstrip(), source)
+
+        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.NameConstant(value=False))
+        source = "spam = False"
+        self.assertEqual(self.to_source(tree).rstrip(), source)
+
+        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.NameConstant(value=None))
+        source = "spam = None"
+        self.assertEqual(self.to_source(tree).rstrip(), source)
+
     @unittest.skipIf(sys.version_info >= (3, 8),
-                     "ast.Bytes, ast.Ellipsis, ast.NameConstant, ast.Num, and ast.Str deprecated in Python 3.8")
+                     "ast.Bytes, ast.Ellipsis, ast.Num, and ast.Str deprecated in Python 3.8")
     def test_deprecated_constant_nodes(self):
-        tree = ast.Num(3)
-        source = "3"
+        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Num(3))
+        source = "spam = 3"
         self.assertEqual(self.to_source(tree).rstrip(), source)
 
-        tree = ast.Num(-93)
-        source = "-93"
+        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Num(-93))
+        source = "spam = -93"
         self.assertEqual(self.to_source(tree).rstrip(), source)
 
-        tree = ast.Num(837.3888)
-        source = "837.3888"
+        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Num(837.3888))
+        source = "spam = 837.3888"
         self.assertEqual(self.to_source(tree).rstrip(), source)
 
-        tree = ast.Num(-0.9877)
-        source = "-0.9877"
-        self.assertEqual(self.to_source(tree).rstrip(), source)
-
-        tree = ast.NameConstant(value=True)
-        source = "True"
-        self.assertEqual(self.to_source(tree).rstrip(), source)
-
-        tree = ast.NameConstant(value=False)
-        source = "False"
-        self.assertEqual(self.to_source(tree).rstrip(), source)
-
-        tree = ast.NameConstant(value=None)
-        source = "None"
+        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Num(-0.9877))
+        source = "spam = -0.9877"
         self.assertEqual(self.to_source(tree).rstrip(), source)
 
         tree = ast.Ellipsis()
         source = "..."
         self.assertEqual(self.to_source(tree).rstrip(), source)
 
-        tree = ast.Str("String")
-        source = '"String"'
+        if sys.version_info >= (3, 0):
+            tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Bytes(b"Bytes"))
+            source = "spam = b'Bytes'"
+            self.assertEqual(self.to_source(tree).rstrip(), source)
+
+        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Str("String"))
+        source = "spam = 'String'"
         self.assertEqual(self.to_source(tree).rstrip(), source)
 
     @unittest.skipUnless(sys.version_info >= (3, 6),
                          "ast.Constant introduced in Python 3.6")
     def test_constant_nodes(self):
-        tree = ast.Constant(value=3)
-        source = "3"
+        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Constant(value=3))
+        source = "spam = 3"
         self.assertEqual(self.to_source(tree).rstrip(), source)
 
-        tree = ast.Constant(value=-93)
-        source = "-93"
+        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Constant(value=-93))
+        source = "spam = -93"
         self.assertEqual(self.to_source(tree).rstrip(), source)
 
-        tree = ast.Constant(value=837.3888)
-        source = "837.3888"
+        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Constant(value=837.3888))
+        source = "spam = 837.3888"
         self.assertEqual(self.to_source(tree).rstrip(), source)
 
-        tree = ast.Constant(value=-0.9877)
-        source = "-0.9877"
+        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Constant(value=-0.9877))
+        source = "spam = -0.9877"
         self.assertEqual(self.to_source(tree).rstrip(), source)
 
-        tree = ast.Constant(value=True)
-        source = "True"
+        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Constant(value=True))
+        source = "spam = True"
         self.assertEqual(self.to_source(tree).rstrip(), source)
 
-        tree = ast.Constant(value=False)
-        source = "False"
+        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Constant(value=False))
+        source = "spam = False"
         self.assertEqual(self.to_source(tree).rstrip(), source)
 
-        tree = ast.Constant(value=None)
-        source = "None"
+        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Constant(value=None))
+        source = "spam = None"
         self.assertEqual(self.to_source(tree).rstrip(), source)
 
         tree = ast.Constant(value=Ellipsis)
         source = "..."
         self.assertEqual(self.to_source(tree).rstrip(), source)
 
-        tree = ast.Constant(value="String")
-        source = '"String"'
+        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Constant(b"Bytes"))
+        source = "spam = b'Bytes'"
+        self.assertEqual(self.to_source(tree).rstrip(), source)
+
+        tree = ast.Assign(targets=[ast.Name(id='spam')], value=ast.Constant(value="String"))
+        source = "spam = 'String'"
         self.assertEqual(self.to_source(tree).rstrip(), source)
 
     def test_annassign(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, pypy, pypy3.5
+envlist = py27, py34, py35, py36, py37, pypy, pypy3.5
 skipsdist = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, py37, pypy, pypy3.5
+envlist = py27, py34, py35, py36, py37, py38, pypy, pypy3.5
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
This PR adds `SourceGenerator.visit_Constant` to handle Python 3.8 deprecating older constant AST node types. I reused a lot of the logic from the exist node types by breaking them out into private handlers for the node value. For a few of the node types this ended up being a little gnarly, so let me know if you have some other ideas for how to organize this code. I didn't want to duplicate a lot of the functionality, since there was a lot there (especially for strings and numeric types) that was probably learned with a lot of bug reports.

I'm not sure exactly how easily you can test this _specific_ code until the Python compiler is emitting these constant nodes directly, but I'm happy to look into it more if you'd like. Locally (at least) the existing tests were passing for me.

Fixes #120 