### PR TITLE
Fix string parsing with newline

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ And with some modifications based on Armin's code:
 * Lenny Truong <leonardtruong@protonmail.com>
 * Radomír Bosák <radomir.bosak@gmail.com>
 * Kodi Arfer <git@arfer.net>
+* Felix Yan <felixonmars@archlinux.org>

--- a/astor/code_gen.py
+++ b/astor/code_gen.py
@@ -168,8 +168,6 @@ class SourceGenerator(ExplicitNodeVisitor):
                     visit(item)
                 elif callable(item):
                     item()
-                elif item == '\n':
-                    newline()
                 else:
                     if self.new_lines:
                         append('\n' * self.new_lines)
@@ -566,7 +564,7 @@ class SourceGenerator(ExplicitNodeVisitor):
             def recurse(node):
                 for value in node.values:
                     if isinstance(value, ast.Str):
-                        self.result.append(value.s)
+                        self.write(value.s)
                     elif isinstance(value, ast.FormattedValue):
                         with self.delimit('{}'):
                             self.visit(value.value)

--- a/astor/code_gen.py
+++ b/astor/code_gen.py
@@ -566,7 +566,7 @@ class SourceGenerator(ExplicitNodeVisitor):
             def recurse(node):
                 for value in node.values:
                     if isinstance(value, ast.Str):
-                        self.write(value.s)
+                        self.result.append(value.s)
                     elif isinstance(value, ast.FormattedValue):
                         with self.delimit('{}'):
                             self.visit(value.value)

--- a/astor/code_gen.py
+++ b/astor/code_gen.py
@@ -218,7 +218,7 @@ class SourceGenerator(ExplicitNodeVisitor):
 
     def else_body(self, elsewhat):
         if elsewhat:
-            self.write('\n', 'else:')
+            self.write(self.newline, 'else:')
             self.body(elsewhat)
 
     def body_or_else(self, node):
@@ -357,7 +357,7 @@ class SourceGenerator(ExplicitNodeVisitor):
             if len(else_) == 1 and isinstance(else_[0], ast.If):
                 node = else_[0]
                 set_precedence(node, node.test)
-                self.write('\n', 'elif ', node.test, ':')
+                self.write(self.newline, 'elif ', node.test, ':')
                 self.body(node.body)
             else:
                 self.else_body(else_)

--- a/astor/source_repr.py
+++ b/astor/source_repr.py
@@ -71,7 +71,7 @@ def wrap_line(line, maxline=79, result=[], count=count):
 
     indentation = line[0]
     lenfirst = len(indentation)
-    indent = lenfirst - len(indentation.strip())
+    indent = lenfirst - len(indentation.lstrip())
     assert indent in (0, lenfirst)
     indentation = line.pop(0) if indent else ''
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,12 +13,14 @@ New features
 Bug fixes
 ~~~~~~~~~
 
-* Fix string parsing with newline in f-string (Reported by Adam and fixed by
-  Felix Yan in `Issue 119`_.)
+* Fix string parsing when there is a newline inside an f-string. (Reported by
+  Adam Cécile in `Issue 119`_ and fixed by Felix Yan in `PR 123`_.)
+
 * Fixed code generation with escaped braces in f-strings.
   (Reported by Felix Yan in `Issue 124`_ and fixed by Kodi Arfer in `PR 125`_.)
 
 .. _`Issue 119`: https://github.com/berkerpeksag/astor/issues/119
+.. _`PR 123`: https://github.com/berkerpeksag/astor/pull/123
 .. _`Issue 124`: https://github.com/berkerpeksag/astor/issues/124
 .. _`PR 125`: https://github.com/berkerpeksag/astor/pull/125
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,7 +13,8 @@ New features
 Bug fixes
 ~~~~~~~~~
 
-*
+* Fix string parsing with newline in f-string (Reported by Adam and fixed by
+  Felix Yan in `Issue 119`_.)
 
 0.7.1 - 2018-07-06
 ------------------

--- a/tests/test_code_gen.py
+++ b/tests/test_code_gen.py
@@ -516,6 +516,11 @@ class CodegenTestCase(unittest.TestCase, Comparisons):
         x = f"""{host}\n\t{port}\n"""
         '''
         self.assertSrcRoundtripsGtVer(source, (3, 6))
+        source = '''
+        if 1:
+            x = f'{host}\\n\\t{port}\\n'
+        '''
+        self.assertSrcRoundtripsGtVer(source, (3, 6))
 
     def test_docstring_function(self):
         source = '''


### PR DESCRIPTION
When looping over a joined str, if a node is ast.Str and the value is
just a newline "\n", the write() function adds an additional indentation
after it, which fails to represent the original string. By calling
self.result.append() here directly the issue is resolved.

The added test could show the issue. With code_gen unmodifed, it fails
with the following error:

```
AssertionError: "if 1:\n    x = f'{host}\\n\\t{port}\\n    '" != "if
1:\n    x = f'{host}\\n\\t{port}\\n'"
  if 1:
      -     x = f'{host}\n\t{port}\n    '?
      ----
      +     x = f'{host}\n\t{port}\n'
```

Which is exactly the problem.

This fixes parsing issues with many of Python 3.7's stdlib. Namely the
following ones:

/usr/lib/python3.7/warnings.py
/usr/lib/python3.7/netrc.py
/usr/lib/python3.7/test/test_embed.py
/usr/lib/python3.7/test/support/testresult.py
/usr/lib/python3.7/idlelib/grep.py