### PR TITLE
Fix various packaging issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ coverage.xml
 
 # Sphinx documentation
 docs/_build/
+
+all_expr_*.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ zip_safe = True
 include_package_data = True
 packages = find:
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*
+tests_require = astunparse
 
 [options.packages.find]
 exclude = tests

--- a/tests/check_astunparse.py
+++ b/tests/check_astunparse.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     import unittest
 
-import test_code_gen
+from . import test_code_gen
 
 import astunparse
 

--- a/tests/check_expressions.py
+++ b/tests/check_expressions.py
@@ -33,7 +33,7 @@ except ImportError:
         import all_expr_2_6 as mymod
     except ImportError:
         print("Expression list does not exist -- building")
-        import build_expressions
+        from . import build_expressions
         build_expressions.makelib()
         print("Expression list built")
         import all_expr_2_6 as mymod
@@ -44,7 +44,7 @@ else:
         mymod = importlib.import_module(mymodname)
     except ImportError:
         print("Expression list does not exist -- building")
-        import build_expressions
+        from . import build_expressions
         build_expressions.makelib()
         print("Expression list built")
         mymod = importlib.import_module(mymodname)


### PR DESCRIPTION
I'm trying to build an RPM package for astor (well, really I'm trying to build a package for Hy) and I came across a few issues during packaging that are fixed here. Mostly the relative imports should use the explicit "from ." syntax so they work outside of a pipenv.

I still get some test failures when trying to build astor but I think they're unrelated to packaging issues.