### PR TITLE
Use issubclass instead of isinstance to compare SourceGenerator in to_source

### DIFF
--- a/astor/code_gen.py
+++ b/astor/code_gen.py
@@ -53,7 +53,7 @@ def to_source(node, indent_with=' ' * 4, add_line_information=False,
     """
     if source_generator_class is None:
         source_generator_class = SourceGenerator
-    elif not isinstance(source_generator_class, SourceGenerator):
+    elif not issubclass(source_generator_class, SourceGenerator):
         raise TypeError('source_generator_class should be a subclass of SourceGenerator')
     elif not callable(source_generator_class):
         raise TypeError('source_generator_class should be a callable')

--- a/astor/code_gen.py
+++ b/astor/code_gen.py
@@ -18,9 +18,9 @@ this code came from here (in 2012):
 """
 
 import ast
+import inspect
 import math
 import sys
-import inspect
 
 from .op_util import get_op_symbol, get_op_precedence, Precedence
 from .node_util import ExplicitNodeVisitor
@@ -58,7 +58,8 @@ def to_source(node, indent_with=' ' * 4, add_line_information=False,
         raise TypeError('source_generator_class should be a class')
     elif not issubclass(source_generator_class, SourceGenerator):
         raise TypeError('source_generator_class should be a subclass of SourceGenerator')
-    generator = source_generator_class(indent_with, add_line_information, pretty_string)
+    generator = source_generator_class(
+        indent_with, add_line_information, pretty_string)
     generator.visit(node)
     generator.result.append('\n')
     if set(generator.result[0]) == set('\n'):

--- a/astor/code_gen.py
+++ b/astor/code_gen.py
@@ -20,6 +20,7 @@ this code came from here (in 2012):
 import ast
 import math
 import sys
+import inspect
 
 from .op_util import get_op_symbol, get_op_precedence, Precedence
 from .node_util import ExplicitNodeVisitor
@@ -53,12 +54,11 @@ def to_source(node, indent_with=' ' * 4, add_line_information=False,
     """
     if source_generator_class is None:
         source_generator_class = SourceGenerator
+    elif not inspect.isclass(source_generator_class):
+        raise TypeError('source_generator_class should be a class')
     elif not issubclass(source_generator_class, SourceGenerator):
         raise TypeError('source_generator_class should be a subclass of SourceGenerator')
-    elif not callable(source_generator_class):
-        raise TypeError('source_generator_class should be a callable')
-    generator = source_generator_class(
-        indent_with, add_line_information, pretty_string)
+    generator = source_generator_class(indent_with, add_line_information, pretty_string)
     generator.visit(node)
     generator.result.append('\n')
     if set(generator.result[0]) == set('\n'):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,11 @@ Bug fixes
 .. _`Issue 153`: https://github.com/berkerpeksag/astor/issues/153
 .. _`PR 155`: https://github.com/berkerpeksag/astor/pull/155
 
+* Fixed :func:`astor.to_source` incorrectly checking whether *source_generator_class* is a subclass of :class:`astor.code_gen.SourceGenerator`
+
+.. _`PR 164`: https://github.com/berkerpeksag/astor/pull/164
+
+
 0.8.0 - 2019-05-19
 ------------------
 
@@ -87,7 +92,7 @@ Bug fixes
 * Fixed :class:`astor.tree_walk.TreeWalk` when attempting to access attributes
   created by Python's type system (such as ``__dict__`` and ``__weakref__``)
   (Reported and fixed by esupoff in `Issue 136`_ and `PR 137`_.)
-  
+
 .. _`Issue 136`: https://github.com/berkerpeksag/astor/issues/136
 .. _`PR 137`: https://github.com/berkerpeksag/astor/pull/137
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,8 +15,11 @@ Bug fixes
 .. _`Issue 153`: https://github.com/berkerpeksag/astor/issues/153
 .. _`PR 155`: https://github.com/berkerpeksag/astor/pull/155
 
-* Fixed :func:`astor.to_source` incorrectly checking whether *source_generator_class* is a subclass of :class:`astor.code_gen.SourceGenerator`
+* Fixed :func:`astor.to_source` incorrectly checking whether
+  *source_generator_class* is a subclass of :class:`astor.code_gen.SourceGenerator`.
+  (Reported by Yu-Chia "Hank" Liu in `Issue 158`_ and fixed by Will Crichton in `PR 164`_.)
 
+.. _`Issue 158`: https://github.com/berkerpeksag/astor/issues/158
 .. _`PR 164`: https://github.com/berkerpeksag/astor/pull/164
 
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -95,7 +95,7 @@ Bug fixes
 * Fixed :class:`astor.tree_walk.TreeWalk` when attempting to access attributes
   created by Python's type system (such as ``__dict__`` and ``__weakref__``)
   (Reported and fixed by esupoff in `Issue 136`_ and `PR 137`_.)
-
+  
 .. _`Issue 136`: https://github.com/berkerpeksag/astor/issues/136
 .. _`PR 137`: https://github.com/berkerpeksag/astor/pull/137
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -66,7 +66,7 @@ class PublicAPITestCase(unittest.TestCase):
             )
         self.assertEqual(
             str(cm.exception),
-            'source_generator_class should be a class'
+            'source_generator_class should be a class',
         )
 
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -66,7 +66,7 @@ class PublicAPITestCase(unittest.TestCase):
             )
         self.assertEqual(
             str(cm.exception),
-            'source_generator_class should be a callable',
+            'source_generator_class should be a class'
         )
 
 


### PR DESCRIPTION
I believe this is just a bug. If `source_generator_class` is a class, then `isinstance` is not appropriate since it's a class, not a class instance/object.