### PR TITLE
Add space around "->" to make source pep8 friendly

### DIFF
--- a/astor/code_gen.py
+++ b/astor/code_gen.py
@@ -330,7 +330,7 @@ class SourceGenerator(ExplicitNodeVisitor):
         self.statement(node, '%sdef %s' % (prefix, node.name), '(')
         self.visit_arguments(node.args)
         self.write(')')
-        self.conditional_write(' ->', self.get_returns(node))
+        self.conditional_write(' -> ', self.get_returns(node))
         self.write(':')
         self.body(node.body)
         if not self.indentation:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,13 +3,13 @@ Release Notes
 =============
 
 0.9.0 - in development
---------------------
+----------------------
 
-Bug Fixes
+Bug fixes
 ~~~~~~~~~
 
 * Change formatting of function and assignment type annotations to be more
-  PEP8 friendly.
+  :pep:`8` friendly.
   (Contributed by Venkatesh-Prasad Ranganath in `PR 170`_.)
 
 .. _`PR 170`: https://github.com/berkerpeksag/astor/pull/170

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,18 @@
 Release Notes
 =============
 
+0.9.0 - in development
+--------------------
+
+Bug Fixes
+~~~~~~~~~
+
+* Change formatting of function and assignment type annotations to be more
+  PEP8 friendly.
+  (Contributed by Venkatesh-Prasad Ranganath in `PR 170`_.)
+
+.. _`PR 170`: https://github.com/berkerpeksag/astor/pull/170
+
 0.8.1 - 2019-12-10
 ------------------
 

--- a/tests/test_code_gen.py
+++ b/tests/test_code_gen.py
@@ -612,22 +612,20 @@ class CodegenTestCase(unittest.TestCase, Comparisons):
         self.assertAstRoundtripsGtVer(source, (3, 6))
 
     @unittest.skipUnless(sys.version_info >= (3, 6),
-                         "typing and ann assignment was introduced in "
+                         "typing and annotated assignment was introduced in "
                          "Python 3.6")
     def test_function_typing(self):
-        source = """
+        source = canonical("""
         def foo(x : int) ->str:
             i : str = '3'
             return i
-        """
-        srctxt = canonical(source)
-        target = """
+        """)
+        target = canonical("""
         def foo(x: int) -> str:
             i: str = '3'
             return i
-        """
-        trgtxt = canonical(target)
-        self.assertEqual(self.to_source(ast.parse(srctxt)).rstrip(), trgtxt)
+        """)
+        self.assertAstEqualsSource(ast.parse(source), target)
 
     def test_compile_types(self):
         code = '(a + b + c) * (d + e + f)\n'

--- a/tests/test_code_gen.py
+++ b/tests/test_code_gen.py
@@ -611,6 +611,24 @@ class CodegenTestCase(unittest.TestCase, Comparisons):
         """
         self.assertAstRoundtripsGtVer(source, (3, 6))
 
+    @unittest.skipUnless(sys.version_info >= (3, 6),
+                         "typing and ann assignment was introduced in "
+                         "Python 3.6")
+    def test_function_typing(self):
+        source = """
+        def foo(x : int) ->str:
+            i : str = '3'
+            return i
+        """
+        srctxt = canonical(source)
+        target = """
+        def foo(x: int) -> str:
+            i: str = '3'
+            return i
+        """
+        trgtxt = canonical(target)
+        self.assertEqual(self.to_source(ast.parse(srctxt)).rstrip(), trgtxt)
+
     def test_compile_types(self):
         code = '(a + b + c) * (d + e + f)\n'
         for mode in 'exec eval single'.split():


### PR DESCRIPTION
Corresponding test also checks type annotation for parameters and assignment are pep8 friendly.