### PR TITLE
Remove extraneous parenthesis around keys in dict literals

### DIFF
--- a/astor/code_gen.py
+++ b/astor/code_gen.py
@@ -729,6 +729,7 @@ class SourceGenerator(ExplicitNodeVisitor):
             self.write('{1}.__class__()')
 
     def visit_Dict(self, node):
+        set_precedence(Precedence.Comma, *node.keys)
         set_precedence(Precedence.Comma, *node.values)
         with self.delimit('{}'):
             for idx, (key, value) in enumerate(zip(node.keys, node.values)):

--- a/tests/test_code_gen.py
+++ b/tests/test_code_gen.py
@@ -758,6 +758,22 @@ class CodegenTestCase(unittest.TestCase, Comparisons):
         '''
         self.assertSrcRoundtrips(source)
 
+    def test_parenthesis_in_keys_of_dict_literals(self):
+        source = 'spam = {(3):4}'
+        target = 'spam = {3: 4}'
+        astor.to_source(ast.parse(source))
+        self.assertAstEqualsSource(ast.parse(source), target)
+
+        source = 'spam = {(3+4):4}'
+        target = 'spam = {3 + 4: 4}'
+        astor.to_source(ast.parse(source))
+        self.assertAstEqualsSource(ast.parse(source), target)
+
+        source = 'spam = {(3).foo:4}'
+        target = 'spam = {(3).foo: 4}'
+        astor.to_source(ast.parse(source))
+        self.assertAstEqualsSource(ast.parse(source), target)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_code_gen.py
+++ b/tests/test_code_gen.py
@@ -764,7 +764,27 @@ class CodegenTestCase(unittest.TestCase, Comparisons):
         astor.to_source(ast.parse(source))
         self.assertAstEqualsSource(ast.parse(source), target)
 
+        source = 'spam = {3:4}'
+        target = 'spam = {3: 4}'
+        astor.to_source(ast.parse(source))
+        self.assertAstEqualsSource(ast.parse(source), target)
+
+        source = 'spam = {(3.0):4}'
+        target = 'spam = {3.0: 4}'
+        astor.to_source(ast.parse(source))
+        self.assertAstEqualsSource(ast.parse(source), target)
+
+        source = 'spam = {3.0:4}'
+        target = 'spam = {3.0: 4}'
+        astor.to_source(ast.parse(source))
+        self.assertAstEqualsSource(ast.parse(source), target)
+
         source = 'spam = {(3+4):4}'
+        target = 'spam = {3 + 4: 4}'
+        astor.to_source(ast.parse(source))
+        self.assertAstEqualsSource(ast.parse(source), target)
+
+        source = 'spam = {3+4:4}'
         target = 'spam = {3 + 4: 4}'
         astor.to_source(ast.parse(source))
         self.assertAstEqualsSource(ast.parse(source), target)


### PR DESCRIPTION
Change ensures `{3: 4}` and `{(3+4): 4}` are written as `{3: 4}` and `{3 + 4: 4}` instead of as `{(3): 4}` and `{(3 + 4): 4}`, respectively,