### PR TITLE
Use the codeobj name in the key rather than the line number

### DIFF
--- a/astor/file_util.py
+++ b/astor/file_util.py
@@ -95,16 +95,16 @@ class CodeToAst(object):
 
     def __call__(self, codeobj):
         cache = self.cache
-        key = self.get_file_info(codeobj)
+        fname, lineno = self.get_file_info(codeobj)
+        key = (fname, codeobj.__name__)
         result = cache.get(key)
         if result is not None:
             return result
-        fname = key[0]
         cache[(fname, 0)] = mod_ast = self.parse_file(fname)
         for obj in mod_ast.body:
             if not isinstance(obj, ast.FunctionDef):
                 continue
-            cache[(fname, obj.lineno)] = obj
+            cache[(fname, obj.name)] = obj
         return cache[key]
 
 

--- a/astor/file_util.py
+++ b/astor/file_util.py
@@ -95,12 +95,12 @@ class CodeToAst(object):
 
     def __call__(self, codeobj):
         cache = self.cache
-        fname, lineno = self.get_file_info(codeobj)
+        fname = self.get_file_info(codeobj)[0]
         key = (fname, codeobj.__name__)
         result = cache.get(key)
         if result is not None:
             return result
-        cache[(fname, 0)] = mod_ast = self.parse_file(fname)
+        cache[key] = mod_ast = self.parse_file(fname)
         for obj in mod_ast.body:
             if not isinstance(obj, ast.FunctionDef):
                 continue

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,11 @@ Release Notes
 Bug fixes
 ~~~~~~~~~
 
+* Use the codeobj name in the key rather than the line number.
+  (Reported by David Charboneau in `Issue 174`_ and fixed by David Charboneau in `PR 175`_.)
+
+.. _`PR 175`: https://github.com/berkerpeksag/astor/pull/175
+
 * Change formatting of function and assignment type annotations to be more
   :pep:`8` friendly.
   (Contributed by Venkatesh-Prasad Ranganath in `PR 170`_.)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,8 +8,10 @@ Release Notes
 Bug fixes
 ~~~~~~~~~
 
-* Use the codeobj name in the key rather than the line number.
-  (Reported by David Charboneau in `Issue 174`_ and fixed by David Charboneau in `PR 175`_.)
+* Use ``codeobj.__name__`` in the key for the internal cache of
+  :class:`astor.file_util.CodeToAst` rather than the line number to
+  prevent :exc:`KeyError`.
+  (Reported and fixed by David Charboneau in `Issue 174`_ and `PR 175`_.)
 
 .. _`Issue 174`: https://github.com/berkerpeksag/astor/pull/174
 .. _`PR 175`: https://github.com/berkerpeksag/astor/pull/175

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ Bug fixes
 * Use the codeobj name in the key rather than the line number.
   (Reported by David Charboneau in `Issue 174`_ and fixed by David Charboneau in `PR 175`_.)
 
+.. _`Issue 174`: https://github.com/berkerpeksag/astor/pull/174
 .. _`PR 175`: https://github.com/berkerpeksag/astor/pull/175
 
 * Change formatting of function and assignment type annotations to be more

--- a/tests/test_code_to_ast.py
+++ b/tests/test_code_to_ast.py
@@ -1,33 +1,72 @@
-from astor import code_to_ast
-from functools import wraps
+import functools
+import unittest
 
-def example_decorator(f):
-    @wraps(f)
+from astor import code_to_ast
+
+
+def decorator(f):
+    @functools.wraps(f)
     def wrapper(*args, **kwargs):
         return f(*args, **kwargs)
     return wrapper
 
-@example_decorator
-def example_decorated_func():
+
+def simple_decorator(f):
+    f.__decorated__ = True
+    return f
+
+
+def undecorated_func():
     pass
 
-def example_undecorated_func():
+
+@decorator
+def decorated_func():
     pass
 
-@example_decorator
-@example_decorator
+
+@decorator
+@decorator
 def twice_decorated_func():
     pass
 
-def test_code_to_ast():
-    # validate we can get the ast for a decorated function
-    ast = code_to_ast(example_decorated_func)
-    assert ast is not None
 
-    # validate we can get the ast for an undecorated function
-    ast = code_to_ast(example_undecorated_func)
-    assert ast is not None
+@simple_decorator
+def plain_decorated_func():
+    pass
 
-    # validate we can get the ast for a multiply decorated function
-    ast = code_to_ast(twice_decorated_func)
-    assert ast is not None
+
+@simple_decorator
+def simple_decorated_func():
+    pass
+
+
+@simple_decorator
+@decorator
+def twice_decorated_func_2():
+    pass
+
+
+class CodeToASTTestCase(unittest.TestCase):
+
+    def test_decorated(self):
+        self.assertIsNotNone(code_to_ast(decorated_func))
+
+    def test_undecorated(self):
+        self.assertIsNotNone(code_to_ast(undecorated_func))
+
+    def test_twice_decorated(self):
+        self.assertIsNotNone(code_to_ast(twice_decorated_func))
+
+    def test_twice_decorated_2(self):
+        self.assertIsNotNone(code_to_ast(twice_decorated_func_2))
+
+    def test_plain_decorator(self):
+        self.assertIsNotNone(code_to_ast(simple_decorated_func))
+
+    def test_module(self):
+        self.assertIsNotNone(code_to_ast(unittest))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_code_to_ast.py
+++ b/tests/test_code_to_ast.py
@@ -1,0 +1,33 @@
+from astor import code_to_ast
+from functools import wraps
+
+def example_decorator(f):
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        return f(*args, **kwargs)
+    return wrapper
+
+@example_decorator
+def example_decorated_func():
+    pass
+
+def example_undecorated_func():
+    pass
+
+@example_decorator
+@example_decorator
+def twice_decorated_func():
+    pass
+
+def test_code_to_ast():
+    # validate we can get the ast for a decorated function
+    ast = code_to_ast(example_decorated_func)
+    assert ast is not None
+
+    # validate we can get the ast for an undecorated function
+    ast = code_to_ast(example_undecorated_func)
+    assert ast is not None
+
+    # validate we can get the ast for a multiply decorated function
+    ast = code_to_ast(twice_decorated_func)
+    assert ast is not None


### PR DESCRIPTION
The line number can be inconsistent between the codeobj and a FunctionDef.
Fixes #174.