### PR TITLE
Remove nose from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,8 +35,7 @@ zip_safe = True
 include_package_data = True
 packages = find:
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*
-tests_requires = ["nose", "astunparse"]
-test_suite = nose.collector
+tests_requires = ["astunparse"]
 
 [options.packages.find]
 exclude = tests


### PR DESCRIPTION
I ran the tests with `python3 -m unittest2 discover` and everything went fine, so I assume that those strings I'd like to remove with this PR are not really needed.