### PR TITLE
Fix to_source() when optional attributes are missing

### DIFF
--- a/astor/code_gen.py
+++ b/astor/code_gen.py
@@ -307,11 +307,15 @@ class SourceGenerator(ExplicitNodeVisitor):
         self.conditional_write(' = ', node.value)
 
     def visit_ImportFrom(self, node):
-        self.statement(node, 'from ', node.level * '.',
-                       node.module or '', ' import ')
+        if hasattr(node, 'level'): node_level = node.level
+        else: node_level = 0
+        if hasattr(node, 'module'): node_module = node.module
+        else: node_module = ''
+        self.statement(node, 'from ', node_level * '.',
+                        node_module or '', ' import ')
         self.comma_list(node.names)
         # Goofy stuff for Python 2.7 _pyio module
-        if node.module == '__future__' and 'unicode_literals' in (
+        if node_module == '__future__' and 'unicode_literals' in (
                 x.name for x in node.names):
             self.using_unicode_literals = True
 

--- a/astor/code_gen.py
+++ b/astor/code_gen.py
@@ -888,7 +888,8 @@ class SourceGenerator(ExplicitNodeVisitor):
 
     def visit_arg(self, node):
         self.write(node.arg)
-        self.conditional_write(': ', node.annotation)
+        if hasattr(node, 'annotation'):
+            self.conditional_write(': ', node.annotation)
 
     def visit_alias(self, node):
         self.write(node.name)

--- a/astor/code_gen.py
+++ b/astor/code_gen.py
@@ -259,14 +259,16 @@ class SourceGenerator(ExplicitNodeVisitor):
             self.write(write_comma, '/')
 
         loop_args(node.args, node.defaults[offset:])
-        self.conditional_write(write_comma, '*', node.vararg)
+        if hasattr(node, 'vararg'):
+            self.conditional_write(write_comma, '*', node.vararg)
 
         kwonlyargs = self.get_kwonlyargs(node)
         if kwonlyargs:
             if node.vararg is None:
                 self.write(write_comma, '*')
             loop_args(kwonlyargs, node.kw_defaults)
-        self.conditional_write(write_comma, '**', node.kwarg)
+        if hasattr(node, 'kwarg'):
+            self.conditional_write(write_comma, '**', node.kwarg)
 
     def statement(self, node, *params, **kw):
         self.newline(node)

--- a/astor/code_gen.py
+++ b/astor/code_gen.py
@@ -890,7 +890,8 @@ class SourceGenerator(ExplicitNodeVisitor):
 
     def visit_alias(self, node):
         self.write(node.name)
-        self.conditional_write(' as ', node.asname)
+        if hasattr(node, 'asname'):
+            self.conditional_write(' as ', node.asname)
 
     def visit_comprehension(self, node):
         set_precedence(node, node.iter, *node.ifs)

--- a/tests/test_ast_attributes.py
+++ b/tests/test_ast_attributes.py
@@ -1,0 +1,21 @@
+import ast
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+import astor
+
+
+class OptionalAttributesTestCase(unittest.TestCase):
+
+    def test_ImportFrom(self):
+        """ Check ImportFrom node without 'module' and 'level' attributes """
+        tree = ast.ImportFrom(
+            names=[ast.alias(name='math', asname=None)],
+        )
+        self.assertIsInstance(astor.to_source(tree), str)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_ast_attributes.py
+++ b/tests/test_ast_attributes.py
@@ -16,6 +16,17 @@ class OptionalAttributesTestCase(unittest.TestCase):
         )
         self.assertIsInstance(astor.to_source(tree), str)
 
+    def test_arguments(self):
+        """ Check argument node without 'vararg' and 'kwarg attributes """
+        tree = ast.arguments(
+            posonlyargs=[],
+            args=[],
+            kwonlyargs=[],
+            kw_defaults=[],
+            defaults=[],
+        )
+        self.assertIsInstance(astor.to_source(tree), str)
+
     def test_alias(self):
         """ Check alias node without 'asname' attribute """
         tree = ast.alias(name='math')

--- a/tests/test_ast_attributes.py
+++ b/tests/test_ast_attributes.py
@@ -16,6 +16,11 @@ class OptionalAttributesTestCase(unittest.TestCase):
         )
         self.assertIsInstance(astor.to_source(tree), str)
 
+    def test_alias(self):
+        """ Check alias node without 'asname' attribute """
+        tree = ast.alias(name='math')
+        self.assertIsInstance(astor.to_source(tree), str)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_ast_attributes.py
+++ b/tests/test_ast_attributes.py
@@ -27,6 +27,11 @@ class OptionalAttributesTestCase(unittest.TestCase):
         )
         self.assertIsInstance(astor.to_source(tree), str)
 
+    def test_arg(self):
+        """ Check arg node without 'annotation' and 'type_comment' attribute """
+        tree = ast.arg(arg='a')
+        self.assertIsInstance(astor.to_source(tree), str)
+
     def test_alias(self):
         """ Check alias node without 'asname' attribute """
         tree = ast.alias(name='math')


### PR DESCRIPTION
The grammar in the `ast` library is defined with optional attributes for some of the nodes [[1]](https://docs.python.org/3.8/library/ast.html). However, astor.to_source(node) currently requires that all (or most of, anyways) the attributes are set. Therefore, for example the code

`astor.to_source(ast.arg(arg='a'))`

, missing the 'annotation' attribute, will fail with an `AttributeError`.

This problem occur for us when we create our own AST and only specify the mandatory attributes.

This PR starts fixing this problem by checking for the existence of the optional attribute before it is used to generate source code. Currently, the fix is only performed for the nodes required for our use, but if desired, I can fix this for the remaining optional attributes as well.

This PR possibly resolves #185.