### PR TITLE
Change `node_to_source` to `to_source`.

### DIFF
--- a/astor/code_gen.py
+++ b/astor/code_gen.py
@@ -144,7 +144,7 @@ class SourceGenerator(ExplicitNodeVisitor):
     """This visitor is able to transform a well formed syntax tree into Python
     sourcecode.
 
-    For more details have a look at the docstring of the `node_to_source`
+    For more details have a look at the docstring of the `to_source`
     function.
 
     """


### PR DESCRIPTION
The docstring of `SourceGenerator` in `code_gen.py` mentions a `node_to_source` functions, which doesn't seem to exist in this repository. Is this meant to be a reference to the `to_source` function instead?