### PR TITLE
Include parentheses for keyword unpacking when syntactically required

### DIFF
--- a/astor/code_gen.py
+++ b/astor/code_gen.py
@@ -532,7 +532,8 @@ class SourceGenerator(ExplicitNodeVisitor):
         for arg in args:
             write(write_comma, arg)
 
-        set_precedence(Precedence.Comma, *(x.value for x in keywords))
+        set_precedence(Precedence.Comma,
+            *(x.value for x in keywords if x.arg))
         for keyword in keywords:
             # a keyword.arg of None indicates dictionary unpacking
             # (Python >= 3.5)
@@ -729,9 +730,10 @@ class SourceGenerator(ExplicitNodeVisitor):
             self.write('{1}.__class__()')
 
     def visit_Dict(self, node):
-        set_precedence(Precedence.Comma, *node.values)
         with self.delimit('{}'):
             for idx, (key, value) in enumerate(zip(node.keys, node.values)):
+                if key:
+                    set_precedence(Precedence.Comma, value)
                 self.write(', ' if idx else '',
                            key if key else '',
                            ': ' if key else '**', value)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,11 @@ Bug fixes
 
 .. _`PR 170`: https://github.com/berkerpeksag/astor/pull/170
 
+* Include parentheses for keyword unpacking when syntactically required.
+  (Contributed by Kodi Arfer in `PR 202`_.)
+
+.. _`PR 202`: https://github.com/berkerpeksag/astor/pull/202
+
 0.8.1 - 2019-12-10
 ------------------
 

--- a/tests/test_code_gen.py
+++ b/tests/test_code_gen.py
@@ -217,6 +217,12 @@ class CodegenTestCase(unittest.TestCase, Comparisons):
             our_dict = {'a': 1, **{'b': 2, 'c': 3}}"""
         self.assertSrcRoundtripsGtVer(source, (3, 5))
 
+    def test_dictionary_unpacking_parens(self):
+        self.assertSrcRoundtripsGtVer("f(**x)", (3, 5))
+        self.assertSrcRoundtripsGtVer("{**x}", (3, 5))
+        self.assertSrcRoundtripsGtVer("f(**([] or 5))", (3, 5))
+        self.assertSrcRoundtripsGtVer("{**([] or 5)}", (3, 5))
+
     def test_async_def_with_for(self):
         source = """
             async def read_data(db):


### PR DESCRIPTION
Fixes #199.

On my system, with Python 3.9.5, `test_convert_stdlib` fails on the file `/usr/lib/python3.9/xml/dom/minidom.py`, but the same failure occurs with `master`, so it's not my fault.