### PR TITLE
[astor/code_gen.py] Support empty `ast.AnnAssign` like `foo: int`

### DIFF
--- a/astor/code_gen.py
+++ b/astor/code_gen.py
@@ -299,12 +299,15 @@ class SourceGenerator(ExplicitNodeVisitor):
 
     def visit_AnnAssign(self, node):
         set_precedence(node, node.target, node.annotation)
-        set_precedence(Precedence.Comma, node.value)
+        has_value = hasattr(node, "value")
+        if has_value:
+            set_precedence(Precedence.Comma, node.value)
         need_parens = isinstance(node.target, ast.Name) and not node.simple
         begin = '(' if need_parens else ''
         end = ')' if need_parens else ''
         self.statement(node, begin, node.target, end, ': ', node.annotation)
-        self.conditional_write(' = ', node.value)
+        if has_value:
+            self.conditional_write(' = ', node.value)
 
     def visit_ImportFrom(self, node):
         self.statement(node, 'from ', node.level * '.',


### PR DESCRIPTION
Works in Python 3.9+ `ast.unparse`, ended up being a tiny fix to add support to your library