### PR TITLE
Add support for PEP 695 – Type Parameter Syntax

### DIFF
--- a/astor/code_gen.py
+++ b/astor/code_gen.py
@@ -333,7 +333,10 @@ class SourceGenerator(ExplicitNodeVisitor):
         self.generic_visit(node)
 
     def visit_TypeAlias(self, node):
-        self.statement(node, 'type ', node.name, ' = ', node.value)
+        self.statement(node, 'type ', node.name)
+        self.type_params(node)
+        self.write(' = ')
+        self.visit(node.value)
 
     def visit_TypeVar(self, node):
         self.write(node.name)

--- a/astor/code_gen.py
+++ b/astor/code_gen.py
@@ -284,7 +284,7 @@ class SourceGenerator(ExplicitNodeVisitor):
         for idx, item in enumerate(items):
             self.write(', ' if idx else '', item)
         self.write(',' if trailing else '')
-        
+
     def type_params(self, node):
         if getattr(node, 'type_params', []):  # Python >= 3.12
             self.write('[')

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,11 @@ New features
 .. _`Issue 215`: https://github.com/berkerpeksag/astor/issues/215
 .. _`PR 219`: https://github.com/berkerpeksag/astor/pull/219
 
+* Add support for Type Parameter Syntax, see :pep:`695` for more details.
+  (Contributed by am230 in `PR 222`_.)
+
+.. _`PR 222`: https://github.com/berkerpeksag/astor/pull/222
+
 Bug fixes
 ~~~~~~~~~
 

--- a/tests/test_code_gen.py
+++ b/tests/test_code_gen.py
@@ -1085,8 +1085,8 @@ class CodegenTestCase(unittest.TestCase, Comparisons):
     def test_type_alias(self):
         source = '''
         type A = int
-        type B = A
-        type C = B
+        type B[T] = T
+        type C[*V] = tuple[*V,]
         '''
         self.assertSrcRoundtrips(source)
 

--- a/tests/test_code_gen.py
+++ b/tests/test_code_gen.py
@@ -1045,6 +1045,50 @@ class CodegenTestCase(unittest.TestCase, Comparisons):
                 pass
         '''
         self.assertSrcRoundtrips(source)
+        
+    @unittest.skipUnless(sys.version_info >= (3, 12, 0),
+                         "type parameter introduced in Python 3.12")
+    def test_type_parameter_function(self):
+        source = '''
+        def f[T](arg: T) -> T:
+            return arg
+
+
+        def f[*V](*args: *V) -> tuple[*V,]:
+            return args
+
+
+        def f[**P](*args: P.args, **kwargs: P.kwargs):
+            pass
+        '''
+        self.assertSrcRoundtrips(source)
+        
+    @unittest.skipUnless(sys.version_info >= (3, 12, 0),
+                            "type parameter introduced in Python 3.12")
+    def test_type_parameter_class(self):
+        source = '''
+        class Class[T]:
+            pass
+
+
+        class Class[*V]:
+            pass
+
+
+        class Class[**P]:
+            pass
+        '''
+        self.assertSrcRoundtrips(source)
+        
+    @unittest.skipUnless(sys.version_info >= (3, 12, 0),
+                            "type alias statement introduced in Python 3.12")
+    def test_type_alias(self):
+        source = '''
+        type A = int
+        type B = A
+        type C = B
+        '''
+        self.assertSrcRoundtrips(source)
 
 
 if __name__ == '__main__':

--- a/tests/test_code_gen.py
+++ b/tests/test_code_gen.py
@@ -1045,7 +1045,7 @@ class CodegenTestCase(unittest.TestCase, Comparisons):
                 pass
         '''
         self.assertSrcRoundtrips(source)
-        
+
     @unittest.skipUnless(sys.version_info >= (3, 12, 0),
                          "type parameter introduced in Python 3.12")
     def test_type_parameter_function(self):
@@ -1062,7 +1062,7 @@ class CodegenTestCase(unittest.TestCase, Comparisons):
             pass
         '''
         self.assertSrcRoundtrips(source)
-        
+
     @unittest.skipUnless(sys.version_info >= (3, 12, 0),
                             "type parameter introduced in Python 3.12")
     def test_type_parameter_class(self):
@@ -1079,7 +1079,7 @@ class CodegenTestCase(unittest.TestCase, Comparisons):
             pass
         '''
         self.assertSrcRoundtrips(source)
-        
+
     @unittest.skipUnless(sys.version_info >= (3, 12, 0),
                             "type alias statement introduced in Python 3.12")
     def test_type_alias(self):


### PR DESCRIPTION
Add type parameter syntax support [PEP-695](https://peps.python.org/pep-0695/)

```python
type A = int

def f[T](value: T) -> T:
    return value
```

It works above and below 3.12.
Please let me know if anything should be added/adjusted.