### PR TITLE
Add support for except* syntax (PEP 654)

### DIFF
--- a/astor/code_gen.py
+++ b/astor/code_gen.py
@@ -481,8 +481,21 @@ class SourceGenerator(ExplicitNodeVisitor):
             self.statement(node, 'finally:')
             self.body(node.finalbody)
 
-    def visit_ExceptHandler(self, node):
+    # except* (introduced in Python 3.11)
+    def visit_TryStar(self, node):
+        self.statement(node, 'try:')
+        self.body(node.body)
+        for handler in node.handlers:
+            self.visit_ExceptHandler(handler, star=True)
+        self.else_body(node.orelse)
+        if node.finalbody:
+            self.statement(node, 'finally:')
+            self.body(node.finalbody)
+
+    def visit_ExceptHandler(self, node, star=False):
         self.statement(node, 'except')
+        if star:
+            self.write('*')
         if self.conditional_write(' ', node.type):
             self.conditional_write(' as ', node.name)
         self.write(':')

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,11 @@ New features
 
 .. _`PR 222`: https://github.com/berkerpeksag/astor/pull/222
 
+* Add support for except* Syntax, see :pep:`654` for more details.
+  (Contributed by am230 in `PR 223`_.)
+
+.. _`PR 223`: https://github.com/berkerpeksag/astor/pull/223
+
 Bug fixes
 ~~~~~~~~~
 

--- a/tests/test_code_gen.py
+++ b/tests/test_code_gen.py
@@ -149,6 +149,28 @@ class CodegenTestCase(unittest.TestCase, Comparisons):
                     return sorted(iterable, key=key, reverse=True)[:n]"""
         self.assertAstRoundtrips(source)
 
+    @unittest.skipUnless(sys.version_info >= (3, 11, 0),
+                            "except* introduced in Python 3.11")
+    def test_try_star(self):
+        source = """
+            try:
+                pass
+            except* Exception:
+                pass"""
+        self.assertAstRoundtrips(source)
+        source = """
+            try:
+                pass
+            except* ImportError:
+                pass
+            except* ValueError as e:
+                pass
+            else:
+                pass
+            finally:
+                pass"""
+        self.assertAstRoundtrips(source)
+
     def test_del_statement(self):
         source = "del l[0]"
         self.assertSrcRoundtrips(source)


### PR DESCRIPTION
Add [TryStar](https://docs.pyth.onl/ja/3.13/library/ast.html#ast.TryStar) support [PEP 654 – Exception Groups and except*](https://peps.python.org/pep-0654/) [clause except*](https://docs.python.org/3/reference/compound_stmts.html#except-star) (3.11~)

```python
try:
    pass
except* Exception:
    pass
```

It works above and below 3.11!
Please let me know if anything should be added/adjusted.

tasks
- [x] Add test
- [x] Compatibility Check (above and below 3.11)
- [x] Update changelog